### PR TITLE
feat(nix): add Nix Home Manager configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dot_git/
+result

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,18 @@
+{
+  description = "nownabe's dotfiles";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    home-manager = {
+      url = "github:nix-community/home-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { nixpkgs, home-manager, ... }: {
+    homeConfigurations."nownabe" = home-manager.lib.homeManagerConfiguration {
+      pkgs = nixpkgs.legacyPackages.x86_64-linux;
+      modules = [ ./home.nix ];
+    };
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -9,10 +9,16 @@
     };
   };
 
-  outputs = { nixpkgs, home-manager, ... }: {
-    homeConfigurations."nownabe" = home-manager.lib.homeManagerConfiguration {
-      pkgs = nixpkgs.legacyPackages.x86_64-linux;
-      modules = [ ./home.nix ];
+  outputs = { nixpkgs, home-manager, ... }:
+    let
+      username = "nownabe";
+      system = "x86_64-linux";
+    in
+    {
+      homeConfigurations.${username} = home-manager.lib.homeManagerConfiguration {
+        pkgs = nixpkgs.legacyPackages.${system};
+        extraSpecialArgs = { inherit username; };
+        modules = [ ./home.nix ];
+      };
     };
-  };
 }

--- a/home.nix
+++ b/home.nix
@@ -1,0 +1,14 @@
+{ pkgs, ... }:
+
+{
+  home.username = "nownabe";
+  home.homeDirectory = "/home/nownabe";
+  home.stateVersion = "26.05";
+
+  home.packages = with pkgs; [
+    git
+    ripgrep
+  ];
+
+  programs.home-manager.enable = true;
+}

--- a/home.nix
+++ b/home.nix
@@ -1,8 +1,8 @@
-{ pkgs, ... }:
+{ pkgs, username, ... }:
 
 {
-  home.username = "nownabe";
-  home.homeDirectory = "/home/nownabe";
+  home.username = username;
+  home.homeDirectory = "/home/${username}";
   home.stateVersion = "26.05";
 
   home.packages = with pkgs; [


### PR DESCRIPTION
## Summary
- Flake ベースの standalone Home Manager の最小構成を追加
- Chezmoi からの段階的移行の第一歩
- 動作確認用に git, ripgrep を `home.packages` に含む

## Files
- `flake.nix` — nixpkgs-unstable + home-manager、`homeConfigurations."nownabe"` を定義
- `home.nix` — stateVersion 26.05、最小パッケージ、Home Manager 自身の管理
- `.gitignore` — `result` を追加

## 適用手順
```bash
# Nix インストール
sh <(curl -L https://nixos.org/nix/install) --daemon

# Flake 有効化
mkdir -p ~/.config/nix
echo "experimental-features = nix-command flakes" >> ~/.config/nix/nix.conf

# 初回適用
nix run home-manager -- switch --flake .
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)