### PR TITLE
docs: update README with Home Manager setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,6 @@
 curl -fsSL https://raw.githubusercontent.com/nownabe/dotfiles/main/setup.sh | bash
 ```
 
-This script does the following:
-
-1. Install [Nix](https://nixos.org/) via [Determinate Systems installer](https://github.com/DeterminateSystems/nix-installer)
-2. Clone this repository to `~/src/github.com/nownabe/dotfiles`
-3. Create a symlink `~/.dotfiles` pointing to the cloned repository
-4. Apply the [Home Manager](https://nix-community.github.io/home-manager/) configuration
-
-Each step is idempotent, so the script can be run multiple times safely.
-
 ### Chezmoi (deprecated)
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -2,7 +2,20 @@
 
 ## Setting up
 
-### Chezmoi
+```shell
+curl -fsSL https://raw.githubusercontent.com/nownabe/dotfiles/main/setup.sh | bash
+```
+
+This script does the following:
+
+1. Install [Nix](https://nixos.org/) via [Determinate Systems installer](https://github.com/DeterminateSystems/nix-installer)
+2. Clone this repository to `~/src/github.com/nownabe/dotfiles`
+3. Create a symlink `~/.dotfiles` pointing to the cloned repository
+4. Apply the [Home Manager](https://nix-community.github.io/home-manager/) configuration
+
+Each step is idempotent, so the script can be run multiple times safely.
+
+### Chezmoi (deprecated)
 
 ```shell
 sh -c "$(curl -fsLS get.chezmoi.io)" -- init --apply nownabe


### PR DESCRIPTION
## Summary
- Add `setup.sh` usage instructions to the top of the Setting up section
- Mark the Chezmoi setup section as deprecated

## Test plan
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)