### PR TITLE
feat(nix): add direnv and zoxide programs

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -11,4 +11,13 @@
   ];
 
   programs.home-manager.enable = true;
+
+  programs.direnv = {
+    enable = true;
+    nix-direnv.enable = true;
+  };
+
+  programs.zoxide = {
+    enable = true;
+  };
 }


### PR DESCRIPTION
## Summary
- Add `programs.direnv` with nix-direnv integration for automatic environment loading
- Add `programs.zoxide` for smarter directory navigation
- Shell integration will be enabled in Phase 2 (zsh migration)

This is part of Phase 1 of the Chezmoi → Home Manager migration.

## Test plan
- [ ] Run `home-manager switch --flake .`
- [ ] Verify `direnv --version` and `zoxide --version` work

🤖 Generated with [Claude Code](https://claude.com/claude-code)