### PR TITLE
fix(zsh): add pure prompt and use XDG paths consistently

### DIFF
--- a/programs/zsh/config/cdr.zsh
+++ b/programs/zsh/config/cdr.zsh
@@ -1,7 +1,7 @@
 # cdr (recent directories)
 autoload -Uz chpwd_recent_dirs cdr add-zsh-hook
 add-zsh-hook chpwd chpwd_recent_dirs
-zstyle ':chpwd:*' recent-dirs-file "$HOME/.cache/zsh/chpwd-recent-dirs"
+zstyle ':chpwd:*' recent-dirs-file "${XDG_CACHE_HOME:-$HOME/.cache}/zsh/chpwd-recent-dirs"
 zstyle ':chpwd:*' recent-dirs-max 1000
 zstyle ':chpwd:*' recent-dirs-default true
 zstyle ':chpwd:*' recent-dirs-pushd true

--- a/programs/zsh/config/fzf.zsh
+++ b/programs/zsh/config/fzf.zsh
@@ -6,7 +6,7 @@ export FZF_DEFAULT_OPTS="
   --multi
   --cycle
   --walker-skip=.git,node_modules
-  --history=$HOME/.cache/fzf/history
+  --history=${XDG_CACHE_HOME:-$HOME/.cache}/fzf/history
   --history-size=10000
   --bind=ctrl-j:down,ctrl-k:up
   --preview 'batcat --color=always --style=numbers --line-range :500 {}'"
@@ -19,7 +19,7 @@ export FZF_CTRL_R_OPTS="
   --header 'Press CTRL-Y to copy command into clipboard'
   --no-preview"
 
-[[ -d "$HOME/.cache/fzf" ]] || mkdir -p "$HOME/.cache/fzf"
+[[ -d "${XDG_CACHE_HOME:-$HOME/.cache}/fzf" ]] || mkdir -p "${XDG_CACHE_HOME:-$HOME/.cache}/fzf"
 
 function fzf-ghq() {
   local target_dir
@@ -31,10 +31,9 @@ function fzf-ghq() {
   zle reset-prompt
 }
 zle -N fzf-ghq
-bindkey "^[" fzf-ghq
 
 function fzf-cdr() {
-  chpwd_recent_dirs -r "$HOME/.cache/zsh/chpwd-recent-dirs"
+  chpwd_recent_dirs -r "${XDG_CACHE_HOME:-$HOME/.cache}/zsh/chpwd-recent-dirs"
   local selected_dir=$(cdr -l | sed 's/^[0-9]\+ \+//' | fzf --query "$LBUFFER" --preview 'tree -C {}')
   if [ -n "$selected_dir" ]; then
     BUFFER="cd ${selected_dir}"
@@ -43,4 +42,3 @@ function fzf-cdr() {
   zle clear-screen
 }
 zle -N fzf-cdr
-bindkey '^O' fzf-cdr

--- a/programs/zsh/config/keybindings.zsh
+++ b/programs/zsh/config/keybindings.zsh
@@ -1,0 +1,4 @@
+bindkey "^P" history-beginning-search-backward
+bindkey "^N" history-beginning-search-forward
+bindkey "^[" fzf-ghq
+bindkey "^O" fzf-cdr

--- a/programs/zsh/default.nix
+++ b/programs/zsh/default.nix
@@ -1,4 +1,4 @@
-{ ... }:
+{ pkgs, ... }:
 
 {
   xdg.configFile = {
@@ -10,6 +10,7 @@
     "zsh/wsl.zsh".source = ./config/wsl.zsh;
     "zsh/mise.zsh".source = ./config/mise.zsh;
     "zsh/path.zsh".source = ./config/path.zsh;
+    "zsh/keybindings.zsh".source = ./config/keybindings.zsh;
   };
 
   programs.zsh = {
@@ -23,14 +24,13 @@
     history = {
       size = 1000000;
       save = 1000000;
-      path = "$HOME/.cache/zsh/history";
+      path = "\${XDG_CACHE_HOME:-$HOME/.cache}/zsh/history";
       extended = true;
       ignoreDups = true;
       ignoreAllDups = true;
       share = true;
     };
 
-    # setopt options
     setOptions = [
       "AUTO_CD"
       "AUTO_PUSHD"
@@ -76,13 +76,21 @@
       be = "bundle exec";
     };
 
+    plugins = [
+      {
+        name = "pure";
+        src = pkgs.pure-prompt;
+        file = "share/zsh/site-functions/prompt_pure_setup";
+      }
+    ];
+
     initExtra = ''
-      # Additional key bindings (not available in programs.zsh options)
-      bindkey "^P" history-beginning-search-backward
-      bindkey "^N" history-beginning-search-forward
+      # Initialize pure prompt
+      autoload -U promptinit; promptinit
+      prompt pure
 
       # Load config files from ~/.config/zsh/
-      for file in "$HOME/.config/zsh"/*.zsh; do
+      for file in "''${XDG_CONFIG_HOME:-$HOME/.config}/zsh"/*.zsh; do
         [[ -f "$file" ]] && source "$file"
       done
     '';


### PR DESCRIPTION
Closes #32

## Summary
- Add sindresorhus/pure prompt via `plugins`
- Use `${XDG_CACHE_HOME:-$HOME/.cache}` for all cache paths (history, fzf, cdr)
- Use `${XDG_CONFIG_HOME:-$HOME/.config}` for config loading
- Extract all `bindkey` commands to `keybindings.zsh`

## Test plan
- [ ] Run `home-manager switch --flake .`
- [ ] Verify pure prompt is displayed
- [ ] Verify keybindings work (^P, ^N, ^[, ^O)
- [ ] Verify history and cdr use XDG paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)