### PR TITLE
fix(zsh): use XDG_CACHE_HOME for cache paths

### DIFF
--- a/programs/zsh/config/cdr.zsh
+++ b/programs/zsh/config/cdr.zsh
@@ -1,7 +1,7 @@
 # cdr (recent directories)
 autoload -Uz chpwd_recent_dirs cdr add-zsh-hook
 add-zsh-hook chpwd chpwd_recent_dirs
-zstyle ':chpwd:*' recent-dirs-file "$HOME/.cache/zsh/chpwd-recent-dirs"
+zstyle ':chpwd:*' recent-dirs-file "${XDG_CACHE_HOME:-$HOME/.cache}/zsh/chpwd-recent-dirs"
 zstyle ':chpwd:*' recent-dirs-max 1000
 zstyle ':chpwd:*' recent-dirs-default true
 zstyle ':chpwd:*' recent-dirs-pushd true

--- a/programs/zsh/config/fzf.zsh
+++ b/programs/zsh/config/fzf.zsh
@@ -6,7 +6,7 @@ export FZF_DEFAULT_OPTS="
   --multi
   --cycle
   --walker-skip=.git,node_modules
-  --history=$HOME/.cache/fzf/history
+  --history=${XDG_CACHE_HOME:-$HOME/.cache}/fzf/history
   --history-size=10000
   --bind=ctrl-j:down,ctrl-k:up
   --preview 'batcat --color=always --style=numbers --line-range :500 {}'"
@@ -19,7 +19,7 @@ export FZF_CTRL_R_OPTS="
   --header 'Press CTRL-Y to copy command into clipboard'
   --no-preview"
 
-[[ -d "$HOME/.cache/fzf" ]] || mkdir -p "$HOME/.cache/fzf"
+[[ -d "${XDG_CACHE_HOME:-$HOME/.cache}/fzf" ]] || mkdir -p "${XDG_CACHE_HOME:-$HOME/.cache}/fzf"
 
 function fzf-ghq() {
   local target_dir
@@ -34,7 +34,7 @@ zle -N fzf-ghq
 bindkey "^[" fzf-ghq
 
 function fzf-cdr() {
-  chpwd_recent_dirs -r "$HOME/.cache/zsh/chpwd-recent-dirs"
+  chpwd_recent_dirs -r "${XDG_CACHE_HOME:-$HOME/.cache}/zsh/chpwd-recent-dirs"
   local selected_dir=$(cdr -l | sed 's/^[0-9]\+ \+//' | fzf --query "$LBUFFER" --preview 'tree -C {}')
   if [ -n "$selected_dir" ]; then
     BUFFER="cd ${selected_dir}"

--- a/programs/zsh/default.nix
+++ b/programs/zsh/default.nix
@@ -23,7 +23,7 @@
     history = {
       size = 1000000;
       save = 1000000;
-      path = "$HOME/.cache/zsh/history";
+      path = "\${XDG_CACHE_HOME:-$HOME/.cache}/zsh/history";
       extended = true;
       ignoreDups = true;
       ignoreAllDups = true;


### PR DESCRIPTION
## Summary
- Use `${XDG_CACHE_HOME:-$HOME/.cache}` instead of `$HOME/.cache` for all cache paths

Part of #32

## Test plan
- [ ] Run `home-manager switch --flake .`
- [ ] Verify history file is created at correct path

🤖 Generated with [Claude Code](https://claude.com/claude-code)