### PR TITLE
refactor(zsh): extract keybindings to keybindings.zsh

### DIFF
--- a/programs/zsh/config/fzf.zsh
+++ b/programs/zsh/config/fzf.zsh
@@ -31,7 +31,6 @@ function fzf-ghq() {
   zle reset-prompt
 }
 zle -N fzf-ghq
-bindkey "^[" fzf-ghq
 
 function fzf-cdr() {
   chpwd_recent_dirs -r "$HOME/.cache/zsh/chpwd-recent-dirs"
@@ -43,4 +42,3 @@ function fzf-cdr() {
   zle clear-screen
 }
 zle -N fzf-cdr
-bindkey '^O' fzf-cdr

--- a/programs/zsh/config/keybindings.zsh
+++ b/programs/zsh/config/keybindings.zsh
@@ -1,0 +1,4 @@
+bindkey "^P" history-beginning-search-backward
+bindkey "^N" history-beginning-search-forward
+bindkey "^[" fzf-ghq
+bindkey "^O" fzf-cdr

--- a/programs/zsh/default.nix
+++ b/programs/zsh/default.nix
@@ -14,6 +14,7 @@
       src = ./config/prompt.zsh;
       purePromptPath = pkgs.pure-prompt;
     };
+    "zsh/keybindings.zsh".source = ./config/keybindings.zsh;
   };
 
   programs.zsh = {
@@ -81,10 +82,6 @@
     };
 
     initExtra = ''
-      # Additional key bindings (not available in programs.zsh options)
-      bindkey "^P" history-beginning-search-backward
-      bindkey "^N" history-beginning-search-forward
-
       # Load config files from ~/.config/zsh/
       for file in "$HOME/.config/zsh"/*.zsh; do
         [[ -f "$file" ]] && source "$file"


### PR DESCRIPTION
## Summary
- Create `keybindings.zsh` with all bindkey commands
- Remove bindkey from `initExtra` and `fzf.zsh`

Part of #32

## Test plan
- [ ] Run `home-manager switch --flake .`
- [ ] Verify keybindings work (^P, ^N, ^[, ^O)

🤖 Generated with [Claude Code](https://claude.com/claude-code)