### PR TITLE
fix(zsh): use XDG_CONFIG_HOME for config loading

### DIFF
--- a/programs/zsh/default.nix
+++ b/programs/zsh/default.nix
@@ -82,7 +82,7 @@
       bindkey "^N" history-beginning-search-forward
 
       # Load config files from ~/.config/zsh/
-      for file in "$HOME/.config/zsh"/*.zsh; do
+      for file in "''${XDG_CONFIG_HOME:-$HOME/.config}/zsh"/*.zsh; do
         [[ -f "$file" ]] && source "$file"
       done
     '';


### PR DESCRIPTION
## Summary
- Use `${XDG_CONFIG_HOME:-$HOME/.config}` for loading zsh config files

Part of #32

## Test plan
- [ ] Run `home-manager switch --flake .`
- [ ] Verify config files are loaded correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)