### PR TITLE
fix(zsh): use ~/.local/bin instead of ~/bin in PATH

### DIFF
--- a/programs/zsh/config/path.zsh
+++ b/programs/zsh/config/path.zsh
@@ -1,1 +1,1 @@
-export PATH="$HOME/bin:$PATH"
+export PATH="$HOME/.local/bin:$PATH"


### PR DESCRIPTION
## Summary
- Change PATH to use `~/.local/bin` instead of `~/bin`
- Follows XDG Base Directory specification

Closes #32

## Test plan
- [ ] Verify `~/.local/bin` is in PATH after `home-manager switch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)