### PR TITLE
fix(nix): replace deprecated functions

### DIFF
--- a/programs/zsh/default.nix
+++ b/programs/zsh/default.nix
@@ -10,8 +10,7 @@
     "zsh/wsl.zsh".source = ./config/wsl.zsh;
     "zsh/mise.zsh".source = ./config/mise.zsh;
     "zsh/path.zsh".source = ./config/path.zsh;
-    "zsh/prompt.zsh".source = pkgs.substituteAll {
-      src = ./config/prompt.zsh;
+    "zsh/prompt.zsh".source = pkgs.replaceVars ./config/prompt.zsh {
       purePromptPath = pkgs.pure-prompt;
     };
     "zsh/keybindings.zsh".source = ./config/keybindings.zsh;
@@ -84,7 +83,7 @@
       hms = "home-manager switch --flake ~/.dotfiles";
     };
 
-    initExtra = ''
+    initContent = ''
       # Load config files from ~/.config/zsh/
       for file in "''${XDG_CONFIG_HOME:-$HOME/.config}/zsh"/*.zsh; do
         [[ -f "$file" ]] && source "$file"


### PR DESCRIPTION
## Summary
- Replace `substituteAll` with `replaceVars` (removed in newer nixpkgs)
- Replace `initExtra` with `initContent` (deprecated)

## Test plan
- [ ] Run `home-manager switch --flake ~/.dotfiles` without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)