### PR TITLE
fix(nvim): use mkOutOfStoreSymlink for mutable nvim config

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,18 +14,19 @@
       username = "nownabe";
       system = "x86_64-linux";
       pkgs = nixpkgs.legacyPackages.${system};
+      dotfilesDir = "/home/${username}/src/github.com/nownabe/dotfiles";
     in
     {
       homeConfigurations = {
         wsl = home-manager.lib.homeManagerConfiguration {
           inherit pkgs;
-          extraSpecialArgs = { inherit username; isWSL = true; };
+          extraSpecialArgs = { inherit username dotfilesDir; isWSL = true; };
           modules = [ ./home.nix ];
         };
 
         linux = home-manager.lib.homeManagerConfiguration {
           inherit pkgs;
-          extraSpecialArgs = { inherit username; isWSL = false; };
+          extraSpecialArgs = { inherit username dotfilesDir; isWSL = false; };
           modules = [ ./home.nix ];
         };
       };

--- a/programs/nvim/default.nix
+++ b/programs/nvim/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ config, dotfilesDir, ... }:
 
 {
   programs.neovim = {
@@ -6,5 +6,5 @@
     defaultEditor = true;
   };
 
-  xdg.configFile."nvim".source = ./config;
+  xdg.configFile."nvim".source = config.lib.file.mkOutOfStoreSymlink "${dotfilesDir}/programs/nvim/config";
 }


### PR DESCRIPTION
## Summary
- `xdg.configFile."nvim".source` を `mkOutOfStoreSymlink` に変更し、`~/.config/nvim` がリポジトリ内の `programs/nvim/config/` を直接指すようにした
- `flake.nix` に `dotfilesDir` 変数を追加し、`extraSpecialArgs` 経由で各モジュールに渡すようにした
- これにより Neovim の設定ファイルが Nix store 経由の読み取り専用ではなく、直接編集可能になる

## Test plan
- [x] `hms` で Home Manager の適用が成功する
- [x] `~/.config/nvim` が `/home/nownabe/src/github.com/nownabe/dotfiles/programs/nvim/config` を指すことを確認
- [x] config ファイルが書き込み可能であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)