### PR TITLE
fix(claude): resolve powershell.exe not found in notify-windows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,8 @@ Examples:
 
 ### Body
 
+Write all PR body content in **English**.
+
 ```markdown
 ## Summary
 <bullet points summarizing changes>

--- a/programs/claude/scripts/notify-windows
+++ b/programs/claude/scripts/notify-windows
@@ -3,6 +3,15 @@
 title="$1"
 message="$2"
 
-powershell.exe -c "(New-Object Media.SoundPlayer 'C:\\Windows\\Media\\tada.wav').PlaySync()"
+# Find powershell.exe: check PATH first, then known locations
+if command -v powershell.exe &>/dev/null; then
+  POWERSHELL="powershell.exe"
+elif [ -x "/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe" ]; then
+  POWERSHELL="/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe"
+else
+  exit 1
+fi
 
-powershell.exe -Command "[reflection.assembly]::loadwithpartialname('System.Windows.Forms'); \$notify = new-object system.windows.forms.notifyicon; \$notify.icon = [System.Drawing.SystemIcons]::Information; \$notify.visible = \$true; \$notify.showballoontip(10,'${title}','${message}',[system.windows.forms.tooltipicon]::Info)"
+"$POWERSHELL" -c "(New-Object Media.SoundPlayer 'C:\\Windows\\Media\\tada.wav').PlaySync()"
+
+"$POWERSHELL" -Command "[reflection.assembly]::loadwithpartialname('System.Windows.Forms'); \$notify = new-object system.windows.forms.notifyicon; \$notify.icon = [System.Drawing.SystemIcons]::Information; \$notify.visible = \$true; \$notify.showballoontip(10,'${title}','${message}',[system.windows.forms.tooltipicon]::Info)"


### PR DESCRIPTION
## Summary
- `notify-windows` script was silently failing because `powershell.exe` was not on PATH in Nix-managed WSL environments
- Dynamically find `powershell.exe` via `command -v` first, then fall back to the known System32 location

## Test plan
- [x] Run `notify-windows` script directly — confirmed Windows balloon notification appeared
- [ ] Apply with `hms` and verify Claude Code hook triggers notification on task completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)