### PR TITLE
feat(zsh): support bare repo in git wt -b shell wrapper

### DIFF
--- a/docs/plans/bare-repo-worktree.md
+++ b/docs/plans/bare-repo-worktree.md
@@ -356,5 +356,5 @@ Phase 1 (Add bare path to git-wt-helper)
 ## Progress
 
 - [x] **Phase 1**: Add bare path to git-wt-helper (top-level branching)
-- [ ] **Phase 2**: Shell wrapper `git wt -b` bare support
+- [x] **Phase 2**: Shell wrapper `git wt -b` bare support
 - [ ] **Phase 3**: ghq bare clone + auto-create initial worktree

--- a/programs/zsh/config/git.zsh
+++ b/programs/zsh/config/git.zsh
@@ -8,7 +8,11 @@ gitwt() {
     shift
     local git_common_dir
     if git_common_dir=$(git rev-parse --git-common-dir 2>/dev/null); then
-      cd "$git_common_dir/.."
+      if [[ $(git rev-parse --is-bare-repository 2>/dev/null) == true ]]; then
+        cd "$git_common_dir"
+      else
+        cd "$git_common_dir/.."
+      fi
     else
       echo "Not in a git repository" >&2
       return 1

--- a/programs/zsh/config/git.zsh
+++ b/programs/zsh/config/git.zsh
@@ -8,10 +8,10 @@ gitwt() {
     shift
     local git_common_dir
     if git_common_dir=$(git rev-parse --git-common-dir 2>/dev/null); then
-      if [[ $(git rev-parse --is-bare-repository 2>/dev/null) == true ]]; then
-        cd "$git_common_dir"
-      else
+      if [[ "$(basename "$git_common_dir")" == ".git" ]]; then
         cd "$git_common_dir/.."
+      else
+        cd "$git_common_dir"
       fi
     else
       echo "Not in a git repository" >&2


### PR DESCRIPTION
## Summary
- Make `git wt -b` work correctly in bare repo worktrees (Phase 2 of bare repo worktree plan)
- Use `basename` of `--git-common-dir` to detect bare vs non-bare instead of `--is-bare-repository` (which returns `false` inside a worktree of a bare repo)
- Non-bare: `--git-common-dir` returns `.git` dir, so `cd ..` goes to repo root
- Bare: `--git-common-dir` returns bare repo root directly, so `cd` there

## Test plan
- [ ] In a non-bare repo worktree: `git wt -b` returns to repo root
- [ ] In a bare repo worktree: `git wt -b` returns to bare repo root
- [ ] At a bare repo root: `git wt -b` stays at bare repo root