### PR TITLE
fix(git): use basename of git-common-dir to detect bare repo in git-wt-helper

### DIFF
--- a/programs/git/scripts/git-wt-helper
+++ b/programs/git/scripts/git-wt-helper
@@ -456,10 +456,9 @@ done
 shift $((OPTIND - 1))
 
 # Detect repo type and dispatch
-if [[ $(git rev-parse --is-bare-repository 2>/dev/null) == true ]]; then
-  bare_main "$@"
-elif git rev-parse --is-inside-work-tree &>/dev/null; then
+git_common_dir=$(git rev-parse --git-common-dir 2>/dev/null) || die "Not in a git repository"
+if [[ "$(basename "$git_common_dir")" == ".git" ]]; then
   nonbare_main "$@"
 else
-  die "Not in a git repository"
+  bare_main "$@"
 fi


### PR DESCRIPTION
## Summary
- Fix bare repo detection in `git-wt-helper` entry point
- `--is-bare-repository` returns `false` inside a worktree of a bare repo, causing it to fall into the non-bare path and display the main worktree entry in fzf
- Use `basename` of `--git-common-dir` instead: `.git` means non-bare, anything else means bare (same approach as the shell wrapper fix in #63)

## Test plan
- [ ] In a bare repo worktree: `git wt` (fzf) does not show a "(main)" root entry
- [ ] In a non-bare repo worktree: `git wt` (fzf) still shows "(main)" root entry
- [ ] `git wt <branch>` works correctly from both bare and non-bare worktrees