### PR TITLE
feat(nix): enable ssh-agent service

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -59,4 +59,6 @@
     enable = true;
     enableZshIntegration = true;
   };
+
+  services.ssh-agent.enable = true;
 }


### PR DESCRIPTION
## Summary
- Enable `services.ssh-agent` in Home Manager to run ssh-agent as a systemd user service
- SSH_AUTH_SOCK is automatically set via systemd

## Test plan
- [ ] Run `hms` to apply the configuration
- [ ] Verify ssh-agent is running: `systemctl --user status ssh-agent`
- [ ] Verify `SSH_AUTH_SOCK` is set: `echo $SSH_AUTH_SOCK`
- [ ] Verify ssh-add works: `ssh-add -l`