### PR TITLE
fix(nix): allow unfree packages for claude-code installation

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,10 @@
     let
       username = "nownabe";
       system = "x86_64-linux";
-      pkgs = nixpkgs.legacyPackages.${system};
+      pkgs = import nixpkgs {
+        inherit system;
+        config.allowUnfree = true;
+      };
       dotfilesDir = "/home/${username}/src/github.com/nownabe/dotfiles";
     in
     {


### PR DESCRIPTION
## Summary
- Enable `config.allowUnfree = true` in `flake.nix` to fix claude-code package installation error
- Replace `nixpkgs.legacyPackages` with `import nixpkgs` to allow nixpkgs config customization

## Test plan
- [ ] Run `hms` and verify claude-code installs without unfree license errors