### PR TITLE
fix(git): use --git-common-dir for bare repo worktree creation

### DIFF
--- a/programs/git/scripts/git-wt-helper
+++ b/programs/git/scripts/git-wt-helper
@@ -152,7 +152,7 @@ bare_prepare_worktree() {
   local default_branch repo_root unused_worktree
 
   default_branch=$(get_default_branch)
-  repo_root=$(git rev-parse --git-dir)
+  repo_root=$(git rev-parse --git-common-dir)
 
   if [[ $FORCE_NEW == false ]] && unused_worktree=$(bare_find_unused_worktree "$default_branch"); then
     (
@@ -219,7 +219,7 @@ bare_main() {
     if branch_exists "$branch"; then
       local default_branch repo_root
       default_branch=$(get_default_branch)
-      repo_root=$(git rev-parse --git-dir)
+      repo_root=$(git rev-parse --git-common-dir)
 
       if [[ $FORCE_NEW == false ]] && unused_worktree=$(bare_find_unused_worktree "$default_branch"); then
         (

--- a/programs/git/scripts/git-wt-helper
+++ b/programs/git/scripts/git-wt-helper
@@ -157,8 +157,7 @@ bare_prepare_worktree() {
   if [[ $FORCE_NEW == false ]] && unused_worktree=$(bare_find_unused_worktree "$default_branch"); then
     (
       cd "$unused_worktree"
-      git fetch -q origin "$default_branch" 2>/dev/null || true
-      git checkout -q -B "$branch" "origin/$default_branch"
+      git checkout -q -B "$branch" "$default_branch"
     ) >&2
     echo "$unused_worktree"
   else
@@ -224,11 +223,7 @@ bare_main() {
       if [[ $FORCE_NEW == false ]] && unused_worktree=$(bare_find_unused_worktree "$default_branch"); then
         (
           cd "$unused_worktree"
-          if git show-ref --verify --quiet "refs/heads/$branch"; then
-            git checkout -q "$branch"
-          else
-            git checkout -q -b "$branch" "origin/$branch"
-          fi
+          git checkout -q "$branch"
         ) >&2
         echo "$unused_worktree"
       else


### PR DESCRIPTION
## Summary
- Fix incorrect worktree path when running `git wt` from within a worktree
- Replace `git rev-parse --git-dir` with `--git-common-dir` for determining bare repo root
- `--git-dir` returns worktree-specific path (e.g., `repo.git/worktrees/wt-001`), causing new worktrees to be nested incorrectly

## Test plan
- [ ] Run `git wt branch-name` from within an existing worktree (e.g., wt-001)
- [ ] Verify new worktree is created at `repo.git/wt-002` instead of `repo.git/worktrees/wt-001/wt-001`