### PR TITLE
feat(ssh): enable AddKeysToAgent in SSH config

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -61,5 +61,12 @@
     enableZshIntegration = true;
   };
 
+  programs.ssh = {
+    enable = true;
+    matchBlocks."*" = {
+      addKeysToAgent = "yes";
+    };
+  };
+
   services.ssh-agent.enable = true;
 }


### PR DESCRIPTION
## Summary
- Add `programs.ssh` configuration to `home.nix` with `AddKeysToAgent yes` for all hosts
- Uses `matchBlocks."*"` to apply the setting globally and avoid deprecation warnings

## Test plan
- [x] `hms` applies successfully
- [x] `~/.ssh/config` contains `AddKeysToAgent yes`