### PR TITLE
chore(claude): add deny rules for network tools and cloud credentials

### DIFF
--- a/programs/claude/settings.json
+++ b/programs/claude/settings.json
@@ -13,6 +13,9 @@
     ],
     "deny": [
       "Bash(gh pr merge:*)",
+      "Bash(curl *)",
+      "Bash(wget *)",
+      "Bash(sudo *)",
       "Read(**/.env*)",
       "Read(**/*.pem)",
       "Read(**/*.key)",
@@ -24,7 +27,10 @@
       "Read(**/*secret*)",
       "Read(**/*token*)",
       "Read(**/.netrc)",
-      "Read(**/.npmrc)"
+      "Read(**/.npmrc)",
+      "Read(~/.ssh/**)",
+      "Read(~/.aws/**)",
+      "Read(~/.gcloud/**)"
     ]
   },
   "model": "opus",


### PR DESCRIPTION
## Summary
- Add `Bash(curl *)`, `Bash(wget *)`, `Bash(sudo *)` to deny list to block network tools and privilege escalation
- Add `Read(~/.ssh/**)`, `Read(~/.aws/**)`, `Read(~/.gcloud/**)` to deny list to protect cloud and SSH credentials

## Test plan
- [ ] Verify `hms` applies successfully
- [ ] Verify curl/wget/sudo commands are denied
- [ ] Verify SSH/AWS/GCP credential files cannot be read