### PR TITLE
chore(claude): add JSON schema for settings validation

### DIFF
--- a/programs/claude/settings.json
+++ b/programs/claude/settings.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "permissions": {
     "allow": [
       "Bash(grep:*)",


### PR DESCRIPTION
## Summary
- Add `$schema` property pointing to `https://json.schemastore.org/claude-code-settings.json`
- Enables editor autocompletion and validation for Claude Code settings

## Test plan
- [ ] Verify `hms` applies successfully
- [ ] Verify editor shows autocompletion for settings.json properties