### PR TITLE
fix(nvim): switch NES backend from copilot.lua to copilot-lsp

### DIFF
--- a/programs/nvim/config/lazy-lock.json
+++ b/programs/nvim/config/lazy-lock.json
@@ -11,6 +11,7 @@
   "blink.compat": { "branch": "main", "commit": "2ed6d9a28b07fa6f3bface818470605f8896408c" },
   "catppuccin": { "branch": "main", "commit": "beaf41a30c26fd7d6c386d383155cbd65dd554cd" },
   "cmp-dap": { "branch": "master", "commit": "ea92773e84c0ad3288c3bc5e452ac91559669087" },
+  "copilot-lsp": { "branch": "main", "commit": "1b6d8273594643f51bb4c0c1d819bdb21b42159d" },
   "copilot.lua": { "branch": "master", "commit": "3faffefbd6ddeb52578535ec6b730e0b72d7fd1a" },
   "friendly-snippets": { "branch": "main", "commit": "6cd7280adead7f586db6fccbd15d2cac7e2188b9" },
   "gitsigns.nvim": { "branch": "main", "commit": "7010000889bfb6c26065e0b0f7f1e6aa9163edd9" },

--- a/programs/nvim/config/lua/plugins/copilot.lua
+++ b/programs/nvim/config/lua/plugins/copilot.lua
@@ -1,10 +1,20 @@
 return {
-  "zbirenbaum/copilot.lua",
-  cmd = "Copilot",
-  event = "InsertEnter",
-  opts = {
-    -- Disable copilot's own UI; sidekick.nvim handles NES
-    suggestion = { enabled = false },
-    panel = { enabled = false },
+  {
+    "copilotlsp-nvim/copilot-lsp",
+    config = function()
+      vim.lsp.config("copilot_ls", {
+        on_init = function() end,
+      })
+      vim.lsp.enable("copilot_ls")
+    end,
+  },
+  {
+    -- https://github.com/AstroNvim/AstroNvim/blob/main/lua/astronvim/plugins/mason-tool-installer.lua
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    opts = {
+      ensure_installed = {
+        "copilot-language-server",
+      },
+    },
   },
 }

--- a/programs/nvim/config/lua/plugins/sidekick.lua
+++ b/programs/nvim/config/lua/plugins/sidekick.lua
@@ -1,6 +1,7 @@
 return {
   "folke/sidekick.nvim",
-  dependencies = { "zbirenbaum/copilot.lua" },
+  dependencies = { "copilotlsp-nvim/copilot-lsp" },
+  event = "LspAttach",
   opts = {},
   -- stylua: ignore
   keys = {


### PR DESCRIPTION
## Summary
- Replace copilot.lua with copilot-lsp (copilotlsp-nvim/copilot-lsp) as the NES backend
- Install copilot-language-server via mason-tool-installer
- Update sidekick.nvim dependency to copilot-lsp and add LspAttach event trigger
- Update lazy-lock.json with copilot-lsp entry

## Test plan
- [ ] Open Neovim and verify copilot-lsp attaches (`:LspInfo`)
- [ ] Verify NES works with `<tab>` in insert mode
- [ ] Test sidekick.nvim CLI toggle with `<leader>aa`