### PR TITLE
fix(nvim): fix sidekick NES tab keybinding logic

### DIFF
--- a/programs/nvim/config/lua/plugins/sidekick.lua
+++ b/programs/nvim/config/lua/plugins/sidekick.lua
@@ -8,12 +8,10 @@ return {
     {
       "<tab>",
       function()
-        if require("sidekick").nes_jump_or_apply() then
-          return
+        if not require("sidekick").nes_jump_or_apply() then
+          return "<tab>"
         end
-        return "<tab>"
       end,
-      mode = { "i", "n" },
       expr = true,
       desc = "Goto/Apply Next Edit Suggestion",
     },


### PR DESCRIPTION
## Summary
- Fix NES tab keybinding condition logic: return `<tab>` fallback only when `nes_jump_or_apply()` returns false
- Remove explicit `mode = { "i", "n" }` (use lazy.nvim default)

## Test plan
- [ ] Open Neovim, verify `<tab>` applies NES when suggestion is available
- [ ] Verify `<tab>` falls back to normal tab behavior when no NES suggestion exists