### PR TITLE
fix(nvim): switch to copilot.vim and resolve Tab key conflicts

### DIFF
--- a/programs/nvim/config/lazy-lock.json
+++ b/programs/nvim/config/lazy-lock.json
@@ -12,7 +12,7 @@
   "catppuccin": { "branch": "main", "commit": "beaf41a30c26fd7d6c386d383155cbd65dd554cd" },
   "cmp-dap": { "branch": "master", "commit": "ea92773e84c0ad3288c3bc5e452ac91559669087" },
   "copilot-lsp": { "branch": "main", "commit": "1b6d8273594643f51bb4c0c1d819bdb21b42159d" },
-  "copilot.lua": { "branch": "master", "commit": "3faffefbd6ddeb52578535ec6b730e0b72d7fd1a" },
+  "copilot.vim": { "branch": "release", "commit": "a12fd5672110c8aa7e3c8419e28c96943ca179be" },
   "friendly-snippets": { "branch": "main", "commit": "6cd7280adead7f586db6fccbd15d2cac7e2188b9" },
   "gitsigns.nvim": { "branch": "main", "commit": "7010000889bfb6c26065e0b0f7f1e6aa9163edd9" },
   "guess-indent.nvim": { "branch": "main", "commit": "84a4987ff36798c2fc1169cbaff67960aed9776f" },

--- a/programs/nvim/config/lua/plugins/blink.lua
+++ b/programs/nvim/config/lua/plugins/blink.lua
@@ -1,0 +1,10 @@
+return {
+  "saghen/blink.cmp",
+  ---@module 'blink.cmp'
+  ---@type blink.cmp.Config
+  opts = {
+    keymap = {
+      ["<Tab>"] = {},
+    },
+  },
+}

--- a/programs/nvim/config/lua/plugins/copilot.lua
+++ b/programs/nvim/config/lua/plugins/copilot.lua
@@ -9,6 +9,9 @@ return {
     end,
   },
   {
+    "github/copilot.vim",
+  },
+  {
     -- https://github.com/AstroNvim/AstroNvim/blob/main/lua/astronvim/plugins/mason-tool-installer.lua
     "WhoIsSethDaniel/mason-tool-installer.nvim",
     opts = {

--- a/programs/nvim/config/lua/plugins/copilot.lua
+++ b/programs/nvim/config/lua/plugins/copilot.lua
@@ -8,6 +8,7 @@ return {
       vim.lsp.enable("copilot_ls")
     end,
   },
+  -- TODO: Replace copilot.vim with copilot-lsp inline completion when Neovim v0.12 is released (vim.lsp.inline_completion)
   {
     "github/copilot.vim",
   },


### PR DESCRIPTION
## Summary
- Switch from `copilot.lua` to `copilot.vim` for Copilot integration
- Disable Tab keybinding in blink.cmp to avoid conflicts with sidekick NES

## Test plan
- [ ] Verify Copilot suggestions work with copilot.vim
- [ ] Verify blink.cmp completion works without Tab key conflicts
- [ ] Verify NES Tab keybinding works without interference