### PR TITLE
fix(git): use glob pattern for .claude/settings.local.json gitignore

### DIFF
--- a/programs/git/default.nix
+++ b/programs/git/default.nix
@@ -11,7 +11,7 @@ in
     ignores = [
       ".nownabe/"
       ".shogo/"
-      ".claude/settings.local.json"
+      "**/.claude/settings.local.json"
     ];
 
     settings = {


### PR DESCRIPTION
## Summary
- Change gitignore pattern from `.claude/settings.local.json` to `**/.claude/settings.local.json` so that the file is ignored regardless of directory depth (e.g., `programs/nvim/config/.claude/settings.local.json`)

## Test plan
- [x] Verify `programs/nvim/config/.claude/` no longer appears in `git status`
- [x] Verify `hms` applies successfully