### PR TITLE
chore(claude): deny git -C command in permissions

### DIFF
--- a/programs/claude/settings.json
+++ b/programs/claude/settings.json
@@ -12,6 +12,7 @@
       "Bash(gh issue close:*)"
     ],
     "deny": [
+      "Bash(git -C :*)",
       "Bash(gh pr merge:*)",
       "Read(**/.envrc)",
       "Read(**/.env*)"


### PR DESCRIPTION
## Summary
- Add `Bash(git -C :*)` to the deny list in Claude Code settings to prevent execution of `git -C` commands

## Test plan
- [ ] Verify `hms` applies successfully
- [ ] Verify Claude Code denies `git -C` commands