### PR TITLE
feat(nvim): add buffer management keybindings

### DIFF
--- a/programs/nvim/config/lua/plugins/mappings.lua
+++ b/programs/nvim/config/lua/plugins/mappings.lua
@@ -12,6 +12,26 @@ return {
           ["<Leader>ls"] = false,
           ["<Leader>lS"] = false,
 
+          -- Disable default buffer mappings
+          ["<Leader>bp"] = false,
+          ["<Leader>br"] = false,
+          ["<Leader>c"] = false,
+          ["<Leader>C"] = false,
+
+          -- Buffer management (overrides default <Leader>bc and <Leader>bl)
+          ["<Leader>bh"] = {
+            function() require("astrocore.buffer").nav(-vim.v.count1) end,
+            desc = "󰜲 Previous buffer",
+          },
+          ["<Leader>bl"] = {
+            function() require("astrocore.buffer").nav(vim.v.count1) end,
+            desc = "󰜵 Next buffer",
+          },
+          ["<Leader>bc"] = {
+            function() require("astrocore.buffer").close() end,
+            desc = "󰅖 Close current buffer",
+          },
+
           -- Cursor navigation (overrides default <Leader>h and <Leader>l)
           ["<Leader>h"] = { "^", desc = "󰜲 Move to first non-whitespace" },
           ["<Leader>l"] = { "$", desc = "󰜵 Move to end of line" },

--- a/programs/nvim/config/lua/plugins/mappings.lua
+++ b/programs/nvim/config/lua/plugins/mappings.lua
@@ -13,8 +13,15 @@ return {
           ["<Leader>lS"] = false,
 
           -- Disable default buffer mappings
+          ["<Leader>bC"] = false,
           ["<Leader>bp"] = false,
           ["<Leader>br"] = false,
+          ["<Leader>bs"] = false,
+          ["<Leader>bse"] = false,
+          ["<Leader>bsi"] = false,
+          ["<Leader>bsm"] = false,
+          ["<Leader>bsp"] = false,
+          ["<Leader>bsr"] = false,
           ["<Leader>c"] = false,
           ["<Leader>C"] = false,
 


### PR DESCRIPTION
## Summary

- Add `<Leader>bh` to navigate to previous buffer
- Add `<Leader>bl` to navigate to next buffer
- Override `<Leader>bc` to close current buffer (default was close all except current)
- Disable unused default mappings: `<Leader>bp`, `<Leader>br`, `<Leader>c`, `<Leader>C`

Closes #95

## Test plan

- [ ] Verify `<Leader>bh` moves to previous buffer
- [ ] Verify `<Leader>bl` moves to next buffer
- [ ] Verify `<Leader>bc` closes the current buffer
- [ ] Verify `<Leader>bp`, `<Leader>br`, `<Leader>c`, `<Leader>C` are disabled