### PR TITLE
feat(nvim): add LSP keybindings under <Leader>; prefix

### DIFF
--- a/programs/nvim/config/.neoconf.json
+++ b/programs/nvim/config/.neoconf.json
@@ -14,7 +14,8 @@
   },
   "lspconfig": {
     "lua_ls": {
-      "Lua.format.enable": false
+      "Lua.format.enable": false,
+      "Lua.diagnostics.globals": ["Snacks"]
     }
   }
 }

--- a/programs/nvim/config/lua/plugins/mappings.lua
+++ b/programs/nvim/config/lua/plugins/mappings.lua
@@ -25,6 +25,12 @@ return {
           ["<Leader>c"] = false,
           ["<Leader>C"] = false,
 
+          -- Disable default g* LSP mappings
+          ["gD"] = false,
+          ["gd"] = false,
+          ["gI"] = false,
+          ["gy"] = false,
+
           -- Buffer management (overrides default <Leader>bc and <Leader>bl)
           ["<Leader>bh"] = {
             function() require("astrocore.buffer").nav(-vim.v.count1) end,
@@ -43,6 +49,16 @@ return {
           ["<Leader>h"] = { "^", desc = "󰜲 Move to first non-whitespace" },
           ["<Leader>l"] = { "$", desc = "󰜵 Move to end of line" },
           ["<Leader>m"] = { "%", desc = "󰅪 Match nearest [], (), {}" },
+
+          -- Diagnostics
+          ["<Leader>;n"] = {
+            function() vim.diagnostic.open_float() end,
+            desc = "Hover diagnostics",
+          },
+          ["<Leader>;N"] = {
+            function() Snacks.picker.diagnostics() end,
+            desc = "Search diagnostics",
+          },
         },
         v = {
           ["<Leader>la"] = false,
@@ -69,13 +85,156 @@ return {
           ["<Leader>lR"] = false,
           ["<Leader>li"] = false,
           ["<Leader>lI"] = false,
+
+          -- Language Tools group
+          ["<Leader>;"] = { desc = " Language Tools" },
+
+          -- LSP actions
+          ["<Leader>;a"] = {
+            function() vim.lsp.buf.code_action() end,
+            desc = "Code action",
+            cond = "textDocument/codeAction",
+          },
+          ["<Leader>;A"] = {
+            function() vim.lsp.buf.code_action { context = { only = { "source" }, diagnostics = {} } } end,
+            desc = "Source action",
+            cond = "textDocument/codeAction",
+          },
+
+          -- Navigation
+          ["<Leader>;d"] = {
+            function() vim.lsp.buf.definition() end,
+            desc = "Definition",
+            cond = "textDocument/definition",
+          },
+          ["<Leader>;D"] = {
+            function() vim.lsp.buf.declaration() end,
+            desc = "Declaration",
+            cond = "textDocument/declaration",
+          },
+          ["<Leader>;t"] = {
+            function() vim.lsp.buf.type_definition() end,
+            desc = "Type definition",
+            cond = "textDocument/typeDefinition",
+          },
+          ["<Leader>;i"] = {
+            function() Snacks.picker.lsp_implementations() end,
+            desc = "Implementations",
+          },
+          ["<Leader>;R"] = {
+            function() Snacks.picker.lsp_references() end,
+            desc = "References",
+          },
+
+          -- Info
+          ["<Leader>;h"] = {
+            function() vim.lsp.buf.hover() end,
+            desc = "Hover",
+            cond = "textDocument/hover",
+          },
+          ["<Leader>;s"] = {
+            function() vim.lsp.buf.signature_help() end,
+            desc = "Signature help",
+            cond = "textDocument/signatureHelp",
+          },
+
+          -- Refactoring
+          ["<Leader>;r"] = {
+            function() vim.lsp.buf.rename() end,
+            desc = "Rename symbol",
+            cond = "textDocument/rename",
+          },
+          ["<Leader>;f"] = {
+            function() vim.lsp.buf.format(require("astrolsp").format_opts) end,
+            desc = "Format buffer",
+            cond = "textDocument/formatting",
+          },
+
+          -- CodeLens
+          ["<Leader>;l"] = {
+            function() vim.lsp.codelens.refresh() end,
+            desc = "CodeLens refresh",
+            cond = "textDocument/codeLens",
+          },
+          ["<Leader>;L"] = {
+            function() vim.lsp.codelens.run() end,
+            desc = "CodeLens run",
+            cond = "textDocument/codeLens",
+          },
+
+          -- Search
+          ["<Leader>;S"] = {
+            function() Snacks.picker.lsp_workspace_symbols() end,
+            desc = "Workspace symbols",
+          },
+          ["<Leader>;o"] = {
+            function() require("aerial").toggle() end,
+            desc = "Symbols outline",
+          },
+
+          -- Toggles
+          ["<Leader>uf"] = {
+            function() require("astrolsp.toggles").buffer_autoformat() end,
+            desc = "Toggle autoformat (buffer)",
+            cond = "textDocument/formatting",
+          },
+          ["<Leader>uF"] = {
+            function() require("astrolsp.toggles").autoformat() end,
+            desc = "Toggle autoformat (global)",
+            cond = "textDocument/formatting",
+          },
+          ["<Leader>u?"] = {
+            function() require("astrolsp.toggles").signature_help() end,
+            desc = "Toggle signature help",
+            cond = "textDocument/signatureHelp",
+          },
+          ["<Leader>uh"] = {
+            function() require("astrolsp.toggles").buffer_inlay_hints() end,
+            desc = "Toggle inlay hints (buffer)",
+            cond = vim.lsp.inlay_hint and "textDocument/inlayHint" or false,
+          },
+          ["<Leader>uH"] = {
+            function() require("astrolsp.toggles").inlay_hints() end,
+            desc = "Toggle inlay hints (global)",
+            cond = vim.lsp.inlay_hint and "textDocument/inlayHint" or false,
+          },
+          ["<Leader>uL"] = {
+            function() require("astrolsp.toggles").codelens() end,
+            desc = "Toggle CodeLens",
+            cond = "textDocument/codeLens",
+          },
+          ["<Leader>uY"] = {
+            function() require("astrolsp.toggles").buffer_semantic_tokens() end,
+            desc = "Toggle semantic highlight (buffer)",
+            cond = function(client)
+              return client.supports_method "textDocument/semanticTokens/full" and vim.lsp.semantic_tokens
+            end,
+          },
         },
         v = {
           ["<Leader>l"] = false,
           ["<Leader>lf"] = false,
+
+          ["<Leader>;"] = { desc = " Language Tools" },
+          ["<Leader>;a"] = {
+            function() vim.lsp.buf.code_action() end,
+            desc = "Code action",
+            cond = "textDocument/codeAction",
+          },
+          ["<Leader>;f"] = {
+            function() vim.lsp.buf.format(require("astrolsp").format_opts) end,
+            desc = "Format buffer",
+            cond = "textDocument/rangeFormatting",
+          },
         },
         x = {
           ["<Leader>la"] = false,
+
+          ["<Leader>;a"] = {
+            function() vim.lsp.buf.code_action() end,
+            desc = "Code action",
+            cond = "textDocument/codeAction",
+          },
         },
       },
     },

--- a/programs/nvim/config/lua/plugins/mappings.lua
+++ b/programs/nvim/config/lua/plugins/mappings.lua
@@ -177,45 +177,6 @@ return {
             function() require("aerial").toggle() end,
             desc = "Symbols outline",
           },
-
-          -- Toggles
-          ["<Leader>uf"] = {
-            function() require("astrolsp.toggles").buffer_autoformat() end,
-            desc = "Toggle autoformat (buffer)",
-            cond = "textDocument/formatting",
-          },
-          ["<Leader>uF"] = {
-            function() require("astrolsp.toggles").autoformat() end,
-            desc = "Toggle autoformat (global)",
-            cond = "textDocument/formatting",
-          },
-          ["<Leader>u?"] = {
-            function() require("astrolsp.toggles").signature_help() end,
-            desc = "Toggle signature help",
-            cond = "textDocument/signatureHelp",
-          },
-          ["<Leader>uh"] = {
-            function() require("astrolsp.toggles").buffer_inlay_hints() end,
-            desc = "Toggle inlay hints (buffer)",
-            cond = vim.lsp.inlay_hint and "textDocument/inlayHint" or false,
-          },
-          ["<Leader>uH"] = {
-            function() require("astrolsp.toggles").inlay_hints() end,
-            desc = "Toggle inlay hints (global)",
-            cond = vim.lsp.inlay_hint and "textDocument/inlayHint" or false,
-          },
-          ["<Leader>uL"] = {
-            function() require("astrolsp.toggles").codelens() end,
-            desc = "Toggle CodeLens",
-            cond = "textDocument/codeLens",
-          },
-          ["<Leader>uY"] = {
-            function() require("astrolsp.toggles").buffer_semantic_tokens() end,
-            desc = "Toggle semantic highlight (buffer)",
-            cond = function(client)
-              return client.supports_method "textDocument/semanticTokens/full" and vim.lsp.semantic_tokens
-            end,
-          },
         },
         v = {
           ["<Leader>l"] = false,

--- a/programs/nvim/config/lua/plugins/mappings.lua
+++ b/programs/nvim/config/lua/plugins/mappings.lua
@@ -29,7 +29,13 @@ return {
           ["gD"] = false,
           ["gd"] = false,
           ["gI"] = false,
+          ["gra"] = false,
+          ["gri"] = false,
+          ["grn"] = false,
+          ["grr"] = false,
+          ["grt"] = false,
           ["gy"] = false,
+          ["K"] = false,
 
           -- Buffer management (overrides default <Leader>bc and <Leader>bl)
           ["<Leader>bh"] = {
@@ -121,7 +127,7 @@ return {
             function() Snacks.picker.lsp_implementations() end,
             desc = "Implementations",
           },
-          ["<Leader>;R"] = {
+          ["<Leader>;r"] = {
             function() Snacks.picker.lsp_references() end,
             desc = "References",
           },
@@ -139,7 +145,7 @@ return {
           },
 
           -- Refactoring
-          ["<Leader>;r"] = {
+          ["<Leader>;R"] = {
             function() vim.lsp.buf.rename() end,
             desc = "Rename symbol",
             cond = "textDocument/rename",
@@ -151,12 +157,12 @@ return {
           },
 
           -- CodeLens
-          ["<Leader>;l"] = {
+          ["<Leader>;L"] = {
             function() vim.lsp.codelens.refresh() end,
             desc = "CodeLens refresh",
             cond = "textDocument/codeLens",
           },
-          ["<Leader>;L"] = {
+          ["<Leader>;l"] = {
             function() vim.lsp.codelens.run() end,
             desc = "CodeLens run",
             cond = "textDocument/codeLens",


### PR DESCRIPTION
## Summary

- Add LSP keybindings under `<Leader>;` prefix (migrated from old config)
- Replace Telescope with Snacks picker for references, implementations, workspace symbols, and diagnostics
- Disable default `g*` and `K` LSP mappings (`gd`, `gD`, `gI`, `gy`, `gra`, `gri`, `grn`, `grr`, `grt`, `K`)
- Add `Snacks` to lua_ls globals in `.neoconf.json`

### LSP keybindings (`<Leader>;` prefix)

| Key | Action | Mode |
|-----|--------|------|
| `<Leader>;a` | Code action | n, v, x |
| `<Leader>;A` | Source action | n |
| `<Leader>;d` | Definition | n |
| `<Leader>;D` | Declaration | n |
| `<Leader>;t` | Type definition | n |
| `<Leader>;i` | Implementations (Snacks picker) | n |
| `<Leader>;R` | References (Snacks picker) | n |
| `<Leader>;h` | Hover | n |
| `<Leader>;s` | Signature help | n |
| `<Leader>;r` | Rename symbol | n |
| `<Leader>;f` | Format buffer | n, v |
| `<Leader>;l` | CodeLens refresh | n |
| `<Leader>;L` | CodeLens run | n |
| `<Leader>;S` | Workspace symbols (Snacks picker) | n |
| `<Leader>;o` | Symbols outline (aerial) | n |
| `<Leader>;n` | Hover diagnostics | n |
| `<Leader>;N` | Search diagnostics (Snacks picker) | n |

Toggle settings (`<Leader>u*`) are not redefined as AstroNvim defaults are used as-is.

Closes #87

## Test plan

- [ ] Verify `<Leader>;` shows Language Tools group in which-key
- [ ] Verify `<Leader>;d` goes to definition
- [ ] Verify `<Leader>;R` opens Snacks picker for references
- [ ] Verify `<Leader>;a` shows code actions
- [ ] Verify `<Leader>;f` formats buffer
- [ ] Verify default `gd`, `gD`, `K` etc. are disabled