### PR TITLE
feat(nvim): add GitHub URL copy for visual selection

### DIFF
--- a/programs/nvim/config/lua/plugins/mappings.lua
+++ b/programs/nvim/config/lua/plugins/mappings.lua
@@ -98,33 +98,23 @@ return {
           ["<Leader>la"] = false,
 
           -- Copy GitHub URL for selected lines
-          ["<Leader>gy"] = {
+          ["<Leader>y"] = {
             function()
-              Snacks.gitbrowse.open {
-                what = "file",
-                notify = false,
-                open = function(url)
-                  vim.fn.setreg("+", url)
-                  vim.notify("Copied: " .. url)
-                end,
-              }
+              local copy = function(url)
+                vim.fn.setreg("+", url)
+                vim.notify("Copied: " .. url)
+              end
+              vim.ui.select({ "Permalink (commit)", "Default branch" }, { prompt = "Copy GitHub URL" }, function(choice)
+                if not choice then return end
+                if choice == "Permalink (commit)" then
+                  Snacks.gitbrowse.open { what = "permalink", notify = false, open = copy }
+                else
+                  local branch = vim.trim(vim.fn.system("git rev-parse --abbrev-ref origin/HEAD")):gsub("^origin/", "")
+                  Snacks.gitbrowse.open { what = "file", branch = branch, notify = false, open = copy }
+                end
+              end)
             end,
-            desc = "Copy GitHub URL (current branch)",
-          },
-          ["<Leader>gY"] = {
-            function()
-              local branch = vim.trim(vim.fn.system("git rev-parse --abbrev-ref origin/HEAD")):gsub("^origin/", "")
-              Snacks.gitbrowse.open {
-                what = "file",
-                branch = branch,
-                notify = false,
-                open = function(url)
-                  vim.fn.setreg("+", url)
-                  vim.notify("Copied: " .. url)
-                end,
-              }
-            end,
-            desc = "Copy GitHub URL (default branch)",
+            desc = "Copy GitHub URL",
           },
         },
       },

--- a/programs/nvim/config/lua/plugins/mappings.lua
+++ b/programs/nvim/config/lua/plugins/mappings.lua
@@ -96,6 +96,36 @@ return {
         },
         v = {
           ["<Leader>la"] = false,
+
+          -- Copy GitHub URL for selected lines
+          ["<Leader>gy"] = {
+            function()
+              Snacks.gitbrowse.open {
+                what = "file",
+                notify = false,
+                open = function(url)
+                  vim.fn.setreg("+", url)
+                  vim.notify("Copied: " .. url)
+                end,
+              }
+            end,
+            desc = "Copy GitHub URL (current branch)",
+          },
+          ["<Leader>gY"] = {
+            function()
+              local branch = vim.trim(vim.fn.system("git rev-parse --abbrev-ref origin/HEAD")):gsub("^origin/", "")
+              Snacks.gitbrowse.open {
+                what = "file",
+                branch = branch,
+                notify = false,
+                open = function(url)
+                  vim.fn.setreg("+", url)
+                  vim.notify("Copied: " .. url)
+                end,
+              }
+            end,
+            desc = "Copy GitHub URL (default branch)",
+          },
         },
       },
     },

--- a/programs/nvim/config/lua/plugins/mappings.lua
+++ b/programs/nvim/config/lua/plugins/mappings.lua
@@ -100,6 +100,9 @@ return {
           -- Copy GitHub URL for selected lines
           ["<Leader>y"] = {
             function()
+              local line_start = vim.fn.line("v")
+              local line_end = vim.fn.line(".")
+              if line_start > line_end then line_start, line_end = line_end, line_start end
               local copy = function(url)
                 vim.fn.setreg("+", url)
                 vim.notify("Copied: " .. url)
@@ -107,10 +110,10 @@ return {
               vim.ui.select({ "Permalink (commit)", "Default branch" }, { prompt = "Copy GitHub URL" }, function(choice)
                 if not choice then return end
                 if choice == "Permalink (commit)" then
-                  Snacks.gitbrowse.open { what = "permalink", notify = false, open = copy }
+                  Snacks.gitbrowse.open { what = "permalink", line_start = line_start, line_end = line_end, notify = false, open = copy }
                 else
                   local branch = vim.trim(vim.fn.system("git rev-parse --abbrev-ref origin/HEAD")):gsub("^origin/", "")
-                  Snacks.gitbrowse.open { what = "file", branch = branch, notify = false, open = copy }
+                  Snacks.gitbrowse.open { what = "file", branch = branch, line_start = line_start, line_end = line_end, notify = false, open = copy }
                 end
               end)
             end,


### PR DESCRIPTION
## Summary

- Add `<Leader>y` in visual mode to copy GitHub URL with line range to clipboard
- Shows a popup to select URL type:
  - **Permalink (commit)**: `https://github.com/.../blob/{commit hash}/...#LXX-LYY`
  - **Default branch**: `https://github.com/.../blob/main/...#LXX-LYY`
- Uses `Snacks.gitbrowse` with custom `open` handler to copy to clipboard

Closes #91

## Test plan

- [ ] Select lines in visual mode, press `<Leader>y`
- [ ] Verify popup appears with two options
- [ ] Select "Permalink (commit)" → URL with commit hash copied to clipboard
- [ ] Select "Default branch" → URL with default branch copied to clipboard
- [ ] Verify notification appears with the copied URL
- [ ] Press Escape to cancel without copying