### PR TITLE
feat(nvim): add GitHub URL copy to Neo-tree

### DIFF
--- a/programs/nvim/config/lua/plugins/neo-tree.lua
+++ b/programs/nvim/config/lua/plugins/neo-tree.lua
@@ -8,5 +8,29 @@ return {
     }
     opts.window.mappings["<C-h>"] = "open_split"
     opts.window.mappings["<C-v>"] = "open_vsplit"
+    opts.window.mappings["Y"] = "copy_github_url"
+    opts.commands = opts.commands or {}
+    opts.commands.copy_github_url = function(state)
+      local node = state.tree:get_node()
+      local filepath = node:get_id()
+      local git_root = vim.trim(vim.fn.system("git rev-parse --show-toplevel"))
+      local rel_path = filepath:sub(#git_root + 2)
+      local remote_url = vim.trim(vim.fn.system("git remote get-url origin"))
+      remote_url = remote_url:gsub("^ssh://git@", "https://")
+      remote_url = remote_url:gsub("^git@(.+):", "https://%1/")
+      remote_url = remote_url:gsub("%.git$", "")
+      vim.ui.select({ "Permalink (commit)", "Default branch" }, { prompt = "Copy GitHub URL" }, function(choice)
+        if not choice then return end
+        local ref
+        if choice == "Permalink (commit)" then
+          ref = vim.trim(vim.fn.system("git rev-parse HEAD"))
+        else
+          ref = vim.trim(vim.fn.system("git rev-parse --abbrev-ref origin/HEAD")):gsub("^origin/", "")
+        end
+        local url = remote_url .. "/blob/" .. ref .. "/" .. rel_path
+        vim.fn.setreg("+", url)
+        vim.notify("Copied: " .. url)
+      end)
+    end
   end,
 }

--- a/programs/nvim/config/lua/plugins/neo-tree.lua
+++ b/programs/nvim/config/lua/plugins/neo-tree.lua
@@ -8,28 +8,53 @@ return {
     }
     opts.window.mappings["<C-h>"] = "open_split"
     opts.window.mappings["<C-v>"] = "open_vsplit"
-    opts.window.mappings["Y"] = "copy_github_url"
     opts.commands = opts.commands or {}
-    opts.commands.copy_github_url = function(state)
+    opts.commands.copy_selector = function(state)
       local node = state.tree:get_node()
       local filepath = node:get_id()
-      local git_root = vim.trim(vim.fn.system("git rev-parse --show-toplevel"))
-      local rel_path = filepath:sub(#git_root + 2)
-      local remote_url = vim.trim(vim.fn.system("git remote get-url origin"))
-      remote_url = remote_url:gsub("^ssh://git@", "https://")
-      remote_url = remote_url:gsub("^git@(.+):", "https://%1/")
-      remote_url = remote_url:gsub("%.git$", "")
-      vim.ui.select({ "Permalink (commit)", "Default branch" }, { prompt = "Copy GitHub URL" }, function(choice)
-        if not choice then return end
-        local ref
-        if choice == "Permalink (commit)" then
-          ref = vim.trim(vim.fn.system("git rev-parse HEAD"))
-        else
-          ref = vim.trim(vim.fn.system("git rev-parse --abbrev-ref origin/HEAD")):gsub("^origin/", "")
+      local filename = node.name
+      local modify = vim.fn.fnamemodify
+
+      local vals = {
+        ["BASENAME"] = modify(filename, ":r"),
+        ["EXTENSION"] = modify(filename, ":e"),
+        ["FILENAME"] = filename,
+        ["PATH (CWD)"] = modify(filepath, ":."),
+        ["PATH (HOME)"] = modify(filepath, ":~"),
+        ["PATH"] = filepath,
+        ["URI"] = vim.uri_from_fname(filepath),
+      }
+
+      -- Add GitHub URL options if in a git repo
+      vim.fn.system("git rev-parse --is-inside-work-tree")
+      if vim.v.shell_error == 0 then
+        local git_root = vim.trim(vim.fn.system("git rev-parse --show-toplevel"))
+        local rel_path = filepath:sub(#git_root + 2)
+        local remote_url = vim.trim(vim.fn.system("git remote get-url origin"))
+        remote_url = remote_url:gsub("^ssh://git@", "https://")
+        remote_url = remote_url:gsub("^git@(.+):", "https://%1/")
+        remote_url = remote_url:gsub("%.git$", "")
+        local commit = vim.trim(vim.fn.system("git rev-parse HEAD"))
+        local branch = vim.trim(vim.fn.system("git rev-parse --abbrev-ref origin/HEAD")):gsub("^origin/", "")
+        vals["GITHUB (commit)"] = remote_url .. "/blob/" .. commit .. "/" .. rel_path
+        vals["GITHUB (default branch)"] = remote_url .. "/blob/" .. branch .. "/" .. rel_path
+      end
+
+      local options = vim.tbl_filter(function(val) return vals[val] ~= "" end, vim.tbl_keys(vals))
+      if vim.tbl_isempty(options) then
+        vim.notify("No values to copy", vim.log.levels.WARN)
+        return
+      end
+      table.sort(options)
+      vim.ui.select(options, {
+        prompt = "Choose to copy to clipboard:",
+        format_item = function(item) return ("%s: %s"):format(item, vals[item]) end,
+      }, function(choice)
+        local result = vals[choice]
+        if result then
+          vim.notify(("Copied: `%s`"):format(result))
+          vim.fn.setreg("+", result)
         end
-        local url = remote_url .. "/blob/" .. ref .. "/" .. rel_path
-        vim.fn.setreg("+", url)
-        vim.notify("Copied: " .. url)
       end)
     end
   end,


### PR DESCRIPTION
## Summary

- Override Neo-tree's `copy_selector` command (mapped to `Y`) to add GitHub URL options
- Keeps all original options: BASENAME, EXTENSION, FILENAME, PATH (CWD/HOME/absolute), URI
- Adds two new options when in a git repo:
  - **GITHUB (commit)**: permalink with commit hash
  - **GITHUB (default branch)**: URL with default branch

Closes #105

## Test plan

- [ ] Open Neo-tree, focus a file, press `Y`
- [ ] Verify all original options are present (BASENAME, EXTENSION, etc.)
- [ ] Verify GITHUB (commit) and GITHUB (default branch) options appear
- [ ] Select a GitHub option → URL copied to clipboard
- [ ] Select a path option → path copied (original behavior preserved)
- [ ] Test in a non-git directory → GitHub options should not appear