### PR TITLE
fix(nvim): set background color for floating windows

### DIFF
--- a/programs/nvim/config/lua/plugins/colorscheme.lua
+++ b/programs/nvim/config/lua/plugins/colorscheme.lua
@@ -11,6 +11,7 @@ return {
         return {
           NormalFloat = { bg = "NONE" },
           FloatBorder = { bg = "NONE" },
+          FloatTitle = { bg = "NONE" },
         }
       end,
     },

--- a/programs/nvim/config/lua/plugins/colorscheme.lua
+++ b/programs/nvim/config/lua/plugins/colorscheme.lua
@@ -7,6 +7,12 @@ return {
     opts = {
       flavour = "mocha",
       transparent_background = true,
+      custom_highlights = function()
+        return {
+          NormalFloat = { bg = "NONE" },
+          FloatBorder = { bg = "NONE" },
+        }
+      end,
     },
   },
 }

--- a/programs/nvim/config/lua/plugins/colorscheme.lua
+++ b/programs/nvim/config/lua/plugins/colorscheme.lua
@@ -7,6 +7,12 @@ return {
     opts = {
       flavour = "mocha",
       transparent_background = true,
+      custom_highlights = function(colors)
+        return {
+          NormalFloat = { bg = colors.base },
+          FloatBorder = { bg = colors.base },
+        }
+      end,
     },
   },
 }

--- a/programs/nvim/config/lua/plugins/colorscheme.lua
+++ b/programs/nvim/config/lua/plugins/colorscheme.lua
@@ -7,12 +7,6 @@ return {
     opts = {
       flavour = "mocha",
       transparent_background = true,
-      custom_highlights = function(colors)
-        return {
-          NormalFloat = { bg = colors.base },
-          FloatBorder = { bg = colors.base },
-        }
-      end,
     },
   },
 }

--- a/programs/nvim/config/lua/plugins/which-key.lua
+++ b/programs/nvim/config/lua/plugins/which-key.lua
@@ -1,0 +1,8 @@
+return {
+  "folke/which-key.nvim",
+  opts = {
+    win = {
+      border = "rounded",
+    },
+  },
+}


### PR DESCRIPTION
## Summary

- Fix black background on floating windows (which-key, sidekick, snacks) caused by `transparent_background = true`
- Set `NormalFloat` and `FloatBorder` background to Catppuccin's `base` color via `custom_highlights`

Closes #90

## Test plan

- [ ] Open which-key (`<Leader>`) → background should use theme color, not black
- [ ] Open sidekick → background should use theme color
- [ ] Open snacks picker (`<Leader>ff`) → background should use theme color
- [ ] Normal editor background should still be transparent