### PR TITLE
fix(nvim): remove duplicate <Leader>fg disable mapping

### DIFF
--- a/programs/nvim/config/lua/plugins/mappings.lua
+++ b/programs/nvim/config/lua/plugins/mappings.lua
@@ -7,7 +7,6 @@ return {
         n = {
           -- Disable default mappings (astrocore / snacks.nvim)
           ["<Leader>f'"] = false,
-          ["<Leader>fg"] = false,
           ["<Leader>fm"] = false,
           ["<Leader>fw"] = false,
           ["<Leader>fW"] = false,


### PR DESCRIPTION
## Summary

- Remove unnecessary `["<Leader>fg"] = false` since `<Leader>fg` is now remapped to grep

## Test plan

- [ ] Verify `<Leader>fg` works as grep