### PR TITLE
feat(nvim): remove Neo-tree Buf and Git source tabs

### DIFF
--- a/programs/nvim/config/lua/plugins/neo-tree.lua
+++ b/programs/nvim/config/lua/plugins/neo-tree.lua
@@ -7,6 +7,7 @@ return {
       hide_gitignored = false,
     }
     opts.sources = { "filesystem" }
+    opts.source_selector = { winbar = false }
     opts.window.mappings["<C-h>"] = "open_split"
     opts.window.mappings["<C-v>"] = "open_vsplit"
     opts.commands = opts.commands or {}

--- a/programs/nvim/config/lua/plugins/neo-tree.lua
+++ b/programs/nvim/config/lua/plugins/neo-tree.lua
@@ -6,6 +6,7 @@ return {
       hide_dotfiles = false,
       hide_gitignored = false,
     }
+    opts.sources = { "filesystem" }
     opts.window.mappings["<C-h>"] = "open_split"
     opts.window.mappings["<C-v>"] = "open_vsplit"
     opts.commands = opts.commands or {}


### PR DESCRIPTION
## Summary

- Set `sources = { "filesystem" }` to keep only the filesystem source
- Removes Buffers and Git Status tabs from Neo-tree sidebar

Closes #108

## Test plan

- [ ] Open Neo-tree (`<Leader>e`) → only filesystem view, no source tabs
- [ ] Verify `[b` / `]b` no longer cycle through sources