### PR TITLE
fix(nvim): disable unused Neo-tree keybindings

### DIFF
--- a/programs/nvim/config/lua/plugins/neo-tree.lua
+++ b/programs/nvim/config/lua/plugins/neo-tree.lua
@@ -8,6 +8,8 @@ return {
     }
     opts.sources = { "filesystem" }
     opts.source_selector = { winbar = false }
+    opts.window.mappings["[b"] = false
+    opts.window.mappings["]b"] = false
     opts.window.mappings["P"] = false
     opts.window.mappings["<C-b>"] = false
     opts.window.mappings["<C-f>"] = false

--- a/programs/nvim/config/lua/plugins/neo-tree.lua
+++ b/programs/nvim/config/lua/plugins/neo-tree.lua
@@ -17,9 +17,13 @@ return {
     opts.window.mappings["P"] = false
     opts.window.mappings["<C-b>"] = false
     opts.window.mappings["<C-f>"] = false
+    opts.window.mappings["T"] = false
+    opts.window.mappings["Tf"] = false
+    opts.window.mappings["Th"] = false
+    opts.window.mappings["Tv"] = false
     opts.window.mappings["s"] = false
     opts.window.mappings["S"] = false
-    opts.window.mappings["t"] = false
+    opts.window.mappings["t"] = "toggleterm_float"
     opts.window.mappings["w"] = false
     opts.window.mappings["<C-h>"] = "open_split"
     opts.window.mappings["<C-v>"] = "open_vsplit"

--- a/programs/nvim/config/lua/plugins/neo-tree.lua
+++ b/programs/nvim/config/lua/plugins/neo-tree.lua
@@ -8,6 +8,9 @@ return {
     }
     opts.sources = { "filesystem" }
     opts.source_selector = { winbar = false }
+    opts.window.mappings["P"] = false
+    opts.window.mappings["<C-b>"] = false
+    opts.window.mappings["<C-f>"] = false
     opts.window.mappings["s"] = false
     opts.window.mappings["S"] = false
     opts.window.mappings["t"] = false

--- a/programs/nvim/config/lua/plugins/neo-tree.lua
+++ b/programs/nvim/config/lua/plugins/neo-tree.lua
@@ -8,6 +8,10 @@ return {
     }
     opts.sources = { "filesystem" }
     opts.source_selector = { winbar = false }
+    opts.window.mappings["s"] = false
+    opts.window.mappings["S"] = false
+    opts.window.mappings["t"] = false
+    opts.window.mappings["w"] = false
     opts.window.mappings["<C-h>"] = "open_split"
     opts.window.mappings["<C-v>"] = "open_vsplit"
     opts.commands = opts.commands or {}

--- a/programs/nvim/config/lua/plugins/neo-tree.lua
+++ b/programs/nvim/config/lua/plugins/neo-tree.lua
@@ -8,8 +8,12 @@ return {
     }
     opts.sources = { "filesystem" }
     opts.source_selector = { winbar = false }
+    opts.window.mappings["<"] = false
+    opts.window.mappings[">"] = false
     opts.window.mappings["[b"] = false
+    opts.window.mappings["[g"] = false
     opts.window.mappings["]b"] = false
+    opts.window.mappings["]g"] = false
     opts.window.mappings["P"] = false
     opts.window.mappings["<C-b>"] = false
     opts.window.mappings["<C-f>"] = false


### PR DESCRIPTION
## Summary

- Disable `s` (open_vsplit), `S` (open_split), `t` (open_tabnew), `w` (open_with_window_picker)
- Splits are available via `<C-h>` (horizontal) and `<C-v>` (vertical)

## Test plan

- [ ] Verify `s`, `S`, `t`, `w` no longer trigger actions in Neo-tree
- [ ] Verify `<C-h>` and `<C-v>` still work for splits