### PR TITLE
fix(nvim): simplify toggleterm keybindings

### DIFF
--- a/programs/nvim/config/lua/plugins/mappings.lua
+++ b/programs/nvim/config/lua/plugins/mappings.lua
@@ -6,6 +6,15 @@ return {
       mappings = {
         n = {
           -- Disable default mappings (astrocore / snacks.nvim)
+          ["<Leader>t"] = { "<Cmd>ToggleTerm direction=float<CR>", desc = "Toggle terminal" },
+          ["<Leader>tf"] = false,
+          ["<Leader>th"] = false,
+          ["<Leader>tl"] = false,
+          ["<Leader>tn"] = false,
+          ["<Leader>tp"] = false,
+          ["<Leader>tt"] = false,
+          ["<Leader>tu"] = false,
+          ["<Leader>tv"] = false,
           ["<Leader>f'"] = false,
           ["<Leader>fm"] = false,
           ["<Leader>fw"] = false,

--- a/programs/nvim/config/lua/plugins/mappings.lua
+++ b/programs/nvim/config/lua/plugins/mappings.lua
@@ -6,7 +6,7 @@ return {
       mappings = {
         n = {
           -- Disable default mappings (astrocore / snacks.nvim)
-          ["<Leader>t"] = { "<Cmd>ToggleTerm direction=float<CR>", desc = " Toggle terminal" },
+          ["<Leader>t"] = { "<Cmd>ToggleTerm direction=float<CR>", desc = " Toggle terminal" },
           ["<Leader>tf"] = false,
           ["<Leader>th"] = false,
           ["<Leader>tl"] = false,

--- a/programs/nvim/config/lua/plugins/mappings.lua
+++ b/programs/nvim/config/lua/plugins/mappings.lua
@@ -6,7 +6,7 @@ return {
       mappings = {
         n = {
           -- Disable default mappings (astrocore / snacks.nvim)
-          ["<Leader>t"] = { "<Cmd>ToggleTerm direction=float<CR>", desc = "Toggle terminal" },
+          ["<Leader>t"] = { "<Cmd>ToggleTerm direction=float<CR>", desc = " Toggle terminal" },
           ["<Leader>tf"] = false,
           ["<Leader>th"] = false,
           ["<Leader>tl"] = false,


### PR DESCRIPTION
## Summary

- Assign `<Leader>t` directly to ToggleTerm float
- Disable all sub-keys: `tf`, `th`, `tl`, `tn`, `tp`, `tt`, `tu`, `tv`

## Test plan

- [ ] Press `<Leader>t` → floating terminal opens
- [ ] Verify `<Leader>tf`, `th`, etc. no longer trigger actions