### PR TITLE
fix(nvim): improve editor visual settings

### DIFF
--- a/programs/nvim/config/lua/plugins/colorscheme.lua
+++ b/programs/nvim/config/lua/plugins/colorscheme.lua
@@ -12,8 +12,8 @@ return {
           NormalFloat = { bg = "NONE" },
           FloatBorder = { bg = "NONE" },
           FloatTitle = { bg = "NONE" },
-          SnacksIndent = { fg = "#ff0000" },
-          SnacksIndentScope = { fg = "#00ff00" },
+          SnacksIndent = { fg = "#0a0a14" },
+          SnacksIndentScope = { fg = "#181825" },
         }
       end,
     },

--- a/programs/nvim/config/lua/plugins/colorscheme.lua
+++ b/programs/nvim/config/lua/plugins/colorscheme.lua
@@ -7,11 +7,12 @@ return {
     opts = {
       flavour = "mocha",
       transparent_background = true,
-      custom_highlights = function()
+      custom_highlights = function(colors)
         return {
           NormalFloat = { bg = "NONE" },
           FloatBorder = { bg = "NONE" },
           FloatTitle = { bg = "NONE" },
+          SnacksIndent = { fg = "#282839" },
         }
       end,
     },

--- a/programs/nvim/config/lua/plugins/colorscheme.lua
+++ b/programs/nvim/config/lua/plugins/colorscheme.lua
@@ -7,11 +7,15 @@ return {
     opts = {
       flavour = "mocha",
       transparent_background = true,
+      integrations = {
+        snacks = true,
+      },
       custom_highlights = function(colors)
         return {
           NormalFloat = { bg = "NONE" },
           FloatBorder = { bg = "NONE" },
           FloatTitle = { bg = "NONE" },
+          SnacksIndent = { fg = "#000000" },
         }
       end,
     },

--- a/programs/nvim/config/lua/plugins/colorscheme.lua
+++ b/programs/nvim/config/lua/plugins/colorscheme.lua
@@ -15,7 +15,7 @@ return {
           NormalFloat = { bg = "NONE" },
           FloatBorder = { bg = "NONE" },
           FloatTitle = { bg = "NONE" },
-          SnacksIndent = { fg = "#000000", blend = 100 },
+          SnacksIndent = { fg = "#000000" },
         }
       end,
     },

--- a/programs/nvim/config/lua/plugins/colorscheme.lua
+++ b/programs/nvim/config/lua/plugins/colorscheme.lua
@@ -12,7 +12,7 @@ return {
           NormalFloat = { bg = "NONE" },
           FloatBorder = { bg = "NONE" },
           FloatTitle = { bg = "NONE" },
-          SnacksIndent = { fg = "#242435" },
+          SnacksIndent = { fg = "#1f1f30" },
         }
       end,
     },

--- a/programs/nvim/config/lua/plugins/colorscheme.lua
+++ b/programs/nvim/config/lua/plugins/colorscheme.lua
@@ -12,8 +12,6 @@ return {
           NormalFloat = { bg = "NONE" },
           FloatBorder = { bg = "NONE" },
           FloatTitle = { bg = "NONE" },
-          SnacksIndent = { fg = "#0a0a14" },
-          SnacksIndentScope = { fg = "#181825" },
         }
       end,
     },

--- a/programs/nvim/config/lua/plugins/colorscheme.lua
+++ b/programs/nvim/config/lua/plugins/colorscheme.lua
@@ -15,7 +15,7 @@ return {
           NormalFloat = { bg = "NONE" },
           FloatBorder = { bg = "NONE" },
           FloatTitle = { bg = "NONE" },
-          SnacksIndent = { fg = "#000000", blend = 50 },
+          SnacksIndent = { fg = "#000000", blend = 100 },
         }
       end,
     },

--- a/programs/nvim/config/lua/plugins/colorscheme.lua
+++ b/programs/nvim/config/lua/plugins/colorscheme.lua
@@ -15,7 +15,6 @@ return {
           NormalFloat = { bg = "NONE" },
           FloatBorder = { bg = "NONE" },
           FloatTitle = { bg = "NONE" },
-          SnacksIndent = { fg = "#181825" },
         }
       end,
     },

--- a/programs/nvim/config/lua/plugins/colorscheme.lua
+++ b/programs/nvim/config/lua/plugins/colorscheme.lua
@@ -12,7 +12,7 @@ return {
           NormalFloat = { bg = "NONE" },
           FloatBorder = { bg = "NONE" },
           FloatTitle = { bg = "NONE" },
-          SnacksIndent = { fg = "#282839" },
+          SnacksIndent = { fg = "#ff0000" },
         }
       end,
     },

--- a/programs/nvim/config/lua/plugins/colorscheme.lua
+++ b/programs/nvim/config/lua/plugins/colorscheme.lua
@@ -15,7 +15,7 @@ return {
           NormalFloat = { bg = "NONE" },
           FloatBorder = { bg = "NONE" },
           FloatTitle = { bg = "NONE" },
-          SnacksIndent = { fg = "#000000", bg = "#000000" },
+          SnacksIndent = { fg = "#000000" },
         }
       end,
     },

--- a/programs/nvim/config/lua/plugins/colorscheme.lua
+++ b/programs/nvim/config/lua/plugins/colorscheme.lua
@@ -12,7 +12,8 @@ return {
           NormalFloat = { bg = "NONE" },
           FloatBorder = { bg = "NONE" },
           FloatTitle = { bg = "NONE" },
-          SnacksIndent = { fg = "#0a0a14" },
+          SnacksIndent = { fg = "#ff0000" },
+          SnacksIndentScope = { fg = "#00ff00" },
         }
       end,
     },

--- a/programs/nvim/config/lua/plugins/colorscheme.lua
+++ b/programs/nvim/config/lua/plugins/colorscheme.lua
@@ -12,7 +12,7 @@ return {
           NormalFloat = { bg = "NONE" },
           FloatBorder = { bg = "NONE" },
           FloatTitle = { bg = "NONE" },
-          SnacksIndent = { fg = "#1f1f30" },
+          SnacksIndent = { fg = "#0a0a14" },
         }
       end,
     },

--- a/programs/nvim/config/lua/plugins/colorscheme.lua
+++ b/programs/nvim/config/lua/plugins/colorscheme.lua
@@ -15,7 +15,7 @@ return {
           NormalFloat = { bg = "NONE" },
           FloatBorder = { bg = "NONE" },
           FloatTitle = { bg = "NONE" },
-          SnacksIndent = { fg = "#000000" },
+          SnacksIndent = { fg = "#000000", blend = 50 },
         }
       end,
     },

--- a/programs/nvim/config/lua/plugins/colorscheme.lua
+++ b/programs/nvim/config/lua/plugins/colorscheme.lua
@@ -12,6 +12,7 @@ return {
       },
       custom_highlights = function(colors)
         return {
+          LineNr = { fg = colors.overlay0 },
           NormalFloat = { bg = "NONE" },
           FloatBorder = { bg = "NONE" },
           FloatTitle = { bg = "NONE" },

--- a/programs/nvim/config/lua/plugins/colorscheme.lua
+++ b/programs/nvim/config/lua/plugins/colorscheme.lua
@@ -15,7 +15,7 @@ return {
           NormalFloat = { bg = "NONE" },
           FloatBorder = { bg = "NONE" },
           FloatTitle = { bg = "NONE" },
-          SnacksIndent = { fg = "#000000" },
+          SnacksIndent = { fg = "#181825" },
         }
       end,
     },

--- a/programs/nvim/config/lua/plugins/colorscheme.lua
+++ b/programs/nvim/config/lua/plugins/colorscheme.lua
@@ -12,7 +12,7 @@ return {
           NormalFloat = { bg = "NONE" },
           FloatBorder = { bg = "NONE" },
           FloatTitle = { bg = "NONE" },
-          SnacksIndent = { fg = "#ff0000" },
+          SnacksIndent = { fg = "#242435" },
         }
       end,
     },

--- a/programs/nvim/config/lua/plugins/colorscheme.lua
+++ b/programs/nvim/config/lua/plugins/colorscheme.lua
@@ -15,7 +15,7 @@ return {
           NormalFloat = { bg = "NONE" },
           FloatBorder = { bg = "NONE" },
           FloatTitle = { bg = "NONE" },
-          SnacksIndent = { fg = "#000000" },
+          SnacksIndent = { fg = "#000000", bg = "#000000" },
         }
       end,
     },

--- a/programs/nvim/config/lua/plugins/snacks.lua
+++ b/programs/nvim/config/lua/plugins/snacks.lua
@@ -3,7 +3,7 @@ return {
   opts = {
     indent = {
       indent = {
-        enabled = false,
+        char = "┊",
       },
     },
     picker = {

--- a/programs/nvim/config/lua/plugins/snacks.lua
+++ b/programs/nvim/config/lua/plugins/snacks.lua
@@ -1,9 +1,9 @@
 return {
   "folke/snacks.nvim",
   init = function()
-    vim.api.nvim_set_hl(0, "SnacksIndent", { fg = "#0a0a14", blend = 98 })
+    vim.api.nvim_set_hl(0, "SnacksIndent", { fg = "#0a0a14", blend = 100 })
     vim.api.nvim_create_autocmd("ColorScheme", {
-      callback = function() vim.api.nvim_set_hl(0, "SnacksIndent", { fg = "#0a0a14", blend = 98 }) end,
+      callback = function() vim.api.nvim_set_hl(0, "SnacksIndent", { fg = "#0a0a14", blend = 100 }) end,
     })
   end,
   opts = {

--- a/programs/nvim/config/lua/plugins/snacks.lua
+++ b/programs/nvim/config/lua/plugins/snacks.lua
@@ -2,8 +2,8 @@ return {
   "folke/snacks.nvim",
   opts = {
     indent = {
-      indent = {
-        only_scope = true,
+      animate = {
+        enabled = false,
       },
     },
     picker = {

--- a/programs/nvim/config/lua/plugins/snacks.lua
+++ b/programs/nvim/config/lua/plugins/snacks.lua
@@ -1,9 +1,9 @@
 return {
   "folke/snacks.nvim",
   init = function()
-    vim.api.nvim_set_hl(0, "SnacksIndent", { fg = "#1e1e2e", blend = 80 })
+    vim.api.nvim_set_hl(0, "SnacksIndent", { fg = "#1e1e2e", blend = 90 })
     vim.api.nvim_create_autocmd("ColorScheme", {
-      callback = function() vim.api.nvim_set_hl(0, "SnacksIndent", { fg = "#1e1e2e", blend = 80 }) end,
+      callback = function() vim.api.nvim_set_hl(0, "SnacksIndent", { fg = "#1e1e2e", blend = 90 }) end,
     })
   end,
   opts = {

--- a/programs/nvim/config/lua/plugins/snacks.lua
+++ b/programs/nvim/config/lua/plugins/snacks.lua
@@ -1,9 +1,9 @@
 return {
   "folke/snacks.nvim",
   init = function()
-    vim.api.nvim_set_hl(0, "SnacksIndent", { fg = "#000000" })
+    vim.api.nvim_set_hl(0, "SnacksIndent", { fg = "#ffffff" })
     vim.api.nvim_create_autocmd("ColorScheme", {
-      callback = function() vim.api.nvim_set_hl(0, "SnacksIndent", { fg = "#000000" }) end,
+      callback = function() vim.api.nvim_set_hl(0, "SnacksIndent", { fg = "#ffffff" }) end,
     })
   end,
   opts = {

--- a/programs/nvim/config/lua/plugins/snacks.lua
+++ b/programs/nvim/config/lua/plugins/snacks.lua
@@ -1,9 +1,9 @@
 return {
   "folke/snacks.nvim",
   init = function()
-    vim.api.nvim_set_hl(0, "SnacksIndent", { fg = "#ffffff" })
+    vim.api.nvim_set_hl(0, "SnacksIndent", { fg = "#313244", blend = 80 })
     vim.api.nvim_create_autocmd("ColorScheme", {
-      callback = function() vim.api.nvim_set_hl(0, "SnacksIndent", { fg = "#ffffff" }) end,
+      callback = function() vim.api.nvim_set_hl(0, "SnacksIndent", { fg = "#313244", blend = 80 }) end,
     })
   end,
   opts = {

--- a/programs/nvim/config/lua/plugins/snacks.lua
+++ b/programs/nvim/config/lua/plugins/snacks.lua
@@ -1,9 +1,9 @@
 return {
   "folke/snacks.nvim",
   init = function()
-    vim.api.nvim_set_hl(0, "SnacksIndent", { fg = "#313244", blend = 80 })
+    vim.api.nvim_set_hl(0, "SnacksIndent", { fg = "#1e1e2e", blend = 80 })
     vim.api.nvim_create_autocmd("ColorScheme", {
-      callback = function() vim.api.nvim_set_hl(0, "SnacksIndent", { fg = "#313244", blend = 80 }) end,
+      callback = function() vim.api.nvim_set_hl(0, "SnacksIndent", { fg = "#1e1e2e", blend = 80 }) end,
     })
   end,
   opts = {

--- a/programs/nvim/config/lua/plugins/snacks.lua
+++ b/programs/nvim/config/lua/plugins/snacks.lua
@@ -1,9 +1,9 @@
 return {
   "folke/snacks.nvim",
   init = function()
-    vim.api.nvim_set_hl(0, "SnacksIndent", { fg = "#1e1e2e", blend = 95 })
+    vim.api.nvim_set_hl(0, "SnacksIndent", { fg = "#1e1e2e", blend = 98 })
     vim.api.nvim_create_autocmd("ColorScheme", {
-      callback = function() vim.api.nvim_set_hl(0, "SnacksIndent", { fg = "#1e1e2e", blend = 95 }) end,
+      callback = function() vim.api.nvim_set_hl(0, "SnacksIndent", { fg = "#1e1e2e", blend = 98 }) end,
     })
   end,
   opts = {

--- a/programs/nvim/config/lua/plugins/snacks.lua
+++ b/programs/nvim/config/lua/plugins/snacks.lua
@@ -1,12 +1,11 @@
 return {
   "folke/snacks.nvim",
-  init = function()
-    vim.api.nvim_set_hl(0, "SnacksIndent", { fg = "#0a0a14", blend = 100 })
-    vim.api.nvim_create_autocmd("ColorScheme", {
-      callback = function() vim.api.nvim_set_hl(0, "SnacksIndent", { fg = "#0a0a14", blend = 100 }) end,
-    })
-  end,
   opts = {
+    indent = {
+      indent = {
+        enabled = false,
+      },
+    },
     picker = {
       win = {
         input = {

--- a/programs/nvim/config/lua/plugins/snacks.lua
+++ b/programs/nvim/config/lua/plugins/snacks.lua
@@ -3,7 +3,7 @@ return {
   opts = {
     indent = {
       indent = {
-        char = "┊",
+        only_scope = true,
       },
     },
     picker = {

--- a/programs/nvim/config/lua/plugins/snacks.lua
+++ b/programs/nvim/config/lua/plugins/snacks.lua
@@ -1,9 +1,9 @@
 return {
   "folke/snacks.nvim",
   init = function()
-    vim.api.nvim_set_hl(0, "SnacksIndent", { fg = "#ff0000" })
+    vim.api.nvim_set_hl(0, "SnacksIndent", { fg = "#0a0a14" })
     vim.api.nvim_create_autocmd("ColorScheme", {
-      callback = function() vim.api.nvim_set_hl(0, "SnacksIndent", { fg = "#ff0000" }) end,
+      callback = function() vim.api.nvim_set_hl(0, "SnacksIndent", { fg = "#0a0a14" }) end,
     })
   end,
   opts = {

--- a/programs/nvim/config/lua/plugins/snacks.lua
+++ b/programs/nvim/config/lua/plugins/snacks.lua
@@ -1,5 +1,11 @@
 return {
   "folke/snacks.nvim",
+  init = function()
+    vim.api.nvim_set_hl(0, "SnacksIndent", { fg = "#ff0000" })
+    vim.api.nvim_create_autocmd("ColorScheme", {
+      callback = function() vim.api.nvim_set_hl(0, "SnacksIndent", { fg = "#ff0000" }) end,
+    })
+  end,
   opts = {
     picker = {
       win = {

--- a/programs/nvim/config/lua/plugins/snacks.lua
+++ b/programs/nvim/config/lua/plugins/snacks.lua
@@ -1,9 +1,9 @@
 return {
   "folke/snacks.nvim",
   init = function()
-    vim.api.nvim_set_hl(0, "SnacksIndent", { fg = "#1e1e2e", blend = 98 })
+    vim.api.nvim_set_hl(0, "SnacksIndent", { fg = "#0a0a14", blend = 98 })
     vim.api.nvim_create_autocmd("ColorScheme", {
-      callback = function() vim.api.nvim_set_hl(0, "SnacksIndent", { fg = "#1e1e2e", blend = 98 }) end,
+      callback = function() vim.api.nvim_set_hl(0, "SnacksIndent", { fg = "#0a0a14", blend = 98 }) end,
     })
   end,
   opts = {

--- a/programs/nvim/config/lua/plugins/snacks.lua
+++ b/programs/nvim/config/lua/plugins/snacks.lua
@@ -1,11 +1,6 @@
 return {
   "folke/snacks.nvim",
   opts = {
-    indent = {
-      animate = {
-        enabled = false,
-      },
-    },
     picker = {
       win = {
         input = {

--- a/programs/nvim/config/lua/plugins/snacks.lua
+++ b/programs/nvim/config/lua/plugins/snacks.lua
@@ -1,9 +1,9 @@
 return {
   "folke/snacks.nvim",
   init = function()
-    vim.api.nvim_set_hl(0, "SnacksIndent", { fg = "#0a0a14" })
+    vim.api.nvim_set_hl(0, "SnacksIndent", { fg = "#000000" })
     vim.api.nvim_create_autocmd("ColorScheme", {
-      callback = function() vim.api.nvim_set_hl(0, "SnacksIndent", { fg = "#0a0a14" }) end,
+      callback = function() vim.api.nvim_set_hl(0, "SnacksIndent", { fg = "#000000" }) end,
     })
   end,
   opts = {

--- a/programs/nvim/config/lua/plugins/snacks.lua
+++ b/programs/nvim/config/lua/plugins/snacks.lua
@@ -1,9 +1,9 @@
 return {
   "folke/snacks.nvim",
   init = function()
-    vim.api.nvim_set_hl(0, "SnacksIndent", { fg = "#1e1e2e", blend = 90 })
+    vim.api.nvim_set_hl(0, "SnacksIndent", { fg = "#1e1e2e", blend = 95 })
     vim.api.nvim_create_autocmd("ColorScheme", {
-      callback = function() vim.api.nvim_set_hl(0, "SnacksIndent", { fg = "#1e1e2e", blend = 90 }) end,
+      callback = function() vim.api.nvim_set_hl(0, "SnacksIndent", { fg = "#1e1e2e", blend = 95 }) end,
     })
   end,
   opts = {


### PR DESCRIPTION
## Summary
- Enable catppuccin snacks integration for proper highlight group support
- Make non-cursor line numbers more visible (surface1 → overlay0)

## Test plan
- [ ] Verify indent guide lines display with catppuccin's default snacks colors
- [ ] Verify non-cursor line numbers are more readable