### PR TITLE
fix(nvim): use absolute line numbers instead of relative

### DIFF
--- a/programs/nvim/config/lua/plugins/astrocore.lua
+++ b/programs/nvim/config/lua/plugins/astrocore.lua
@@ -1,1 +1,11 @@
-return {}
+return {
+  "AstroNvim/astrocore",
+  ---@type AstroCoreOpts
+  opts = {
+    options = {
+      opt = {
+        relativenumber = false,
+      },
+    },
+  },
+}


### PR DESCRIPTION
## Summary
- Disable `relativenumber` to show absolute line numbers

## Test plan
- [ ] Verify line numbers show absolute values instead of relative distances