### PR TITLE
feat(nvim): enable spell check and diagnostic virtual lines

### DIFF
--- a/programs/nvim/config/lua/plugins/astrocore.lua
+++ b/programs/nvim/config/lua/plugins/astrocore.lua
@@ -9,4 +9,11 @@ return {
       },
     },
   },
+  config = function(_, opts)
+    require("astrocore").setup(opts)
+    vim.diagnostic.config {
+      virtual_text = false,
+      virtual_lines = true,
+    }
+  end,
 }

--- a/programs/nvim/config/lua/plugins/astrocore.lua
+++ b/programs/nvim/config/lua/plugins/astrocore.lua
@@ -5,6 +5,7 @@ return {
     options = {
       opt = {
         relativenumber = false,
+        spell = true,
       },
     },
   },


### PR DESCRIPTION
## Summary
- Enable spell checking
- Enable diagnostic virtual lines (show diagnostics below the line)
- Disable diagnostic virtual text (inline text after the line)

## Test plan
- [ ] Verify spell checking is active
- [ ] Verify diagnostics appear below the line as virtual lines
- [ ] Verify no inline diagnostic text appears after lines
- [ ] Verify `<Leader>uv` / `<Leader>uV` toggles still work