### PR TITLE
feat(nvim): add Lua language support

### DIFF
--- a/programs/nvim/config/.stylua.toml
+++ b/programs/nvim/config/.stylua.toml
@@ -3,5 +3,5 @@ line_endings = "Unix"
 indent_type = "Spaces"
 indent_width = 2
 quote_style = "AutoPreferDouble"
-call_parentheses = "None"
+call_parentheses = "Always"
 collapse_simple_statement = "Always"

--- a/programs/nvim/config/lua/plugins/astrocore.lua
+++ b/programs/nvim/config/lua/plugins/astrocore.lua
@@ -12,9 +12,9 @@ return {
   },
   config = function(_, opts)
     require("astrocore").setup(opts)
-    vim.diagnostic.config {
+    vim.diagnostic.config({
       virtual_text = false,
       virtual_lines = true,
-    }
+    })
   end,
 }

--- a/programs/nvim/config/lua/plugins/astroui.lua
+++ b/programs/nvim/config/lua/plugins/astroui.lua
@@ -3,6 +3,6 @@ return {
   "AstroNvim/astroui",
   ---@type AstroUIOpts
   opts = {
-    colorscheme = "catppuccin"
-  }
+    colorscheme = "catppuccin",
+  },
 }

--- a/programs/nvim/config/lua/plugins/lang/lua.lua
+++ b/programs/nvim/config/lua/plugins/lang/lua.lua
@@ -1,0 +1,79 @@
+-- Lua language support
+-- Based on https://github.com/AstroNvim/astrocommunity/blob/main/lua/astrocommunity/pack/lua/init.lua
+
+local function selene_configured(path)
+  return #vim.fs.find("selene.toml", { path = path, upward = true, type = "file" }) > 0
+end
+
+local is_aarch64 = vim.loop.os_uname().machine == "aarch64"
+
+return {
+  {
+    "AstroNvim/astrolsp",
+    optional = true,
+    opts = {
+      config = {
+        lua_ls = {
+          settings = {
+            Lua = {
+              hint = {
+                enable = true,
+                arrayIndex = "Disable",
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  {
+    "nvim-treesitter/nvim-treesitter",
+    optional = true,
+    opts = function(_, opts)
+      if opts.ensure_installed ~= "all" then
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "lua", "luap" })
+      end
+    end,
+  },
+  {
+    "williamboman/mason-lspconfig.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "lua_ls" })
+    end,
+  },
+  {
+    "jay-babu/mason-null-ls.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, {
+        "stylua",
+        (not is_aarch64 and "selene") or nil,
+      })
+
+      if not opts.handlers then opts.handlers = {} end
+
+      if not is_aarch64 then
+        opts.handlers.selene = function(source_name, methods)
+          local null_ls = require "null-ls"
+          for _, method in ipairs(methods) do
+            null_ls.register(null_ls.builtins[method][source_name].with {
+              runtime_condition = function(params) return selene_configured(params.bufname) end,
+            })
+          end
+        end
+      end
+    end,
+  },
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, {
+        "lua-language-server",
+        "stylua",
+        (not is_aarch64 and "selene") or nil,
+      })
+    end,
+  },
+}

--- a/programs/nvim/config/lua/plugins/lang/lua.lua
+++ b/programs/nvim/config/lua/plugins/lang/lua.lua
@@ -55,11 +55,11 @@ return {
 
       if not is_aarch64 then
         opts.handlers.selene = function(source_name, methods)
-          local null_ls = require "null-ls"
+          local null_ls = require("null-ls")
           for _, method in ipairs(methods) do
-            null_ls.register(null_ls.builtins[method][source_name].with {
+            null_ls.register(null_ls.builtins[method][source_name].with({
               runtime_condition = function(params) return selene_configured(params.bufname) end,
-            })
+            }))
           end
         end
       end

--- a/programs/nvim/config/lua/plugins/mappings.lua
+++ b/programs/nvim/config/lua/plugins/mappings.lua
@@ -90,7 +90,7 @@ return {
             desc = "Grep",
           },
           ["<Leader>fG"] = {
-            function() Snacks.picker.grep { hidden = true, ignored = true } end,
+            function() Snacks.picker.grep({ hidden = true, ignored = true }) end,
             desc = "Grep (all files)",
           },
 
@@ -112,7 +112,9 @@ return {
             function()
               local line_start = vim.fn.line("v")
               local line_end = vim.fn.line(".")
-              if line_start > line_end then line_start, line_end = line_end, line_start end
+              if line_start > line_end then
+                line_start, line_end = line_end, line_start
+              end
               local copy = function(url)
                 vim.fn.setreg("+", url)
                 vim.notify("Copied: " .. url)
@@ -120,10 +122,23 @@ return {
               vim.ui.select({ "Permalink (commit)", "Default branch" }, { prompt = "Copy GitHub URL" }, function(choice)
                 if not choice then return end
                 if choice == "Permalink (commit)" then
-                  Snacks.gitbrowse.open { what = "permalink", line_start = line_start, line_end = line_end, notify = false, open = copy }
+                  Snacks.gitbrowse.open({
+                    what = "permalink",
+                    line_start = line_start,
+                    line_end = line_end,
+                    notify = false,
+                    open = copy,
+                  })
                 else
                   local branch = vim.trim(vim.fn.system("git rev-parse --abbrev-ref origin/HEAD")):gsub("^origin/", "")
-                  Snacks.gitbrowse.open { what = "file", branch = branch, line_start = line_start, line_end = line_end, notify = false, open = copy }
+                  Snacks.gitbrowse.open({
+                    what = "file",
+                    branch = branch,
+                    line_start = line_start,
+                    line_end = line_end,
+                    notify = false,
+                    open = copy,
+                  })
                 end
               end)
             end,
@@ -163,7 +178,7 @@ return {
             cond = "textDocument/codeAction",
           },
           ["<Leader>;A"] = {
-            function() vim.lsp.buf.code_action { context = { only = { "source" }, diagnostics = {} } } end,
+            function() vim.lsp.buf.code_action({ context = { only = { "source" }, diagnostics = {} } }) end,
             desc = "Source action",
             cond = "textDocument/codeAction",
           },

--- a/programs/nvim/config/lua/setup.lua
+++ b/programs/nvim/config/lua/setup.lua
@@ -15,6 +15,7 @@ require("lazy").setup({
   },
   -- { import = "community" },
   { import = "plugins" },
+  { import = "plugins.lang" },
 } --[[@as LazySpec]], {
   -- Configure any other `lazy.nvim` configuration options here
   ui = { backdrop = 100 },

--- a/programs/nvim/config/lua/setup.lua
+++ b/programs/nvim/config/lua/setup.lua
@@ -3,13 +3,13 @@
 require("lazy").setup({
   {
     "AstroNvim/AstroNvim",
-    version = "^5",                -- Remove version tracking to elect for nightly AstroNvim
+    version = "^5", -- Remove version tracking to elect for nightly AstroNvim
     import = "astronvim.plugins",
-    opts = {                       -- AstroNvim options must be set here with the `import` key
-      mapleader = " ",             -- This ensures the leader key must be configured before Lazy is set up
-      maplocalleader = ",",        -- This ensures the localleader key must be configured before Lazy is set up
-      icons_enabled = true,        -- Set to false to disable icons (if no Nerd Font is available)
-      pin_plugins = nil,           -- Default will pin plugins when tracking `version` of AstroNvim, set to true/false to override
+    opts = { -- AstroNvim options must be set here with the `import` key
+      mapleader = " ", -- This ensures the leader key must be configured before Lazy is set up
+      maplocalleader = ",", -- This ensures the localleader key must be configured before Lazy is set up
+      icons_enabled = true, -- Set to false to disable icons (if no Nerd Font is available)
+      pin_plugins = nil, -- Default will pin plugins when tracking `version` of AstroNvim, set to true/false to override
       update_notifications = true, -- Enable/disable notification about running `:Lazy update` twice to update pinned plugins
     },
   },


### PR DESCRIPTION
## Summary
- Add Lua language support configuration based on AstroCommunity's Lua pack
- Configure `lua_ls` with inlay hints via astrolsp
- Add `lua` and `luap` treesitter parsers
- Set up `stylua` (formatter) and `selene` (linter) via mason-null-ls and none-ls
- Ensure tool installation via mason-lspconfig and mason-tool-installer
- Selene is conditionally enabled only when `selene.toml` is present in the project
- Selene is excluded on aarch64 platforms due to binary compatibility

## Test plan
- [ ] Open a Lua file and verify `lua_ls` starts
- [ ] Save a Lua file and verify `stylua` formats it
- [ ] Open a project with `selene.toml` and verify selene diagnostics appear