### PR TITLE
feat(nvim): add vim-matchup for enhanced bracket matching

### DIFF
--- a/programs/nvim/config/lua/plugins/mappings.lua
+++ b/programs/nvim/config/lua/plugins/mappings.lua
@@ -69,7 +69,7 @@ return {
           -- Cursor navigation (overrides default <Leader>h and <Leader>l)
           ["<Leader>h"] = { "^", desc = "󰜲 Move to first non-whitespace" },
           ["<Leader>l"] = { "$", desc = "󰜵 Move to end of line" },
-          ["<Leader>m"] = { "%", desc = "󰅪 Match nearest [], (), {}" },
+          ["<Leader>m"] = { "<Plug>(matchup-%)", desc = "󰅪 Match nearest [], (), {}" },
 
           -- Find files (git files in git repo, otherwise normal find)
           ["<Leader>ff"] = {

--- a/programs/nvim/config/lua/plugins/vim-matchup.lua
+++ b/programs/nvim/config/lua/plugins/vim-matchup.lua
@@ -4,7 +4,11 @@ return {
   "andymass/vim-matchup",
   event = "User AstroFile",
   specs = {
-    { "nvim-treesitter/nvim-treesitter", optional = true },
+    {
+      "nvim-treesitter/nvim-treesitter",
+      optional = true,
+      opts = { matchup = { enable = true } },
+    },
     {
       "AstroNvim/astrocore",
       opts = {

--- a/programs/nvim/config/lua/plugins/vim-matchup.lua
+++ b/programs/nvim/config/lua/plugins/vim-matchup.lua
@@ -1,0 +1,20 @@
+-- https://github.com/andymass/vim-matchup
+-- Based on https://github.com/AstroNvim/astrocommunity/blob/main/lua/astrocommunity/motion/vim-matchup/init.lua
+return {
+  "andymass/vim-matchup",
+  event = "User AstroFile",
+  specs = {
+    { "nvim-treesitter/nvim-treesitter", optional = true },
+    {
+      "AstroNvim/astrocore",
+      opts = {
+        options = {
+          g = {
+            matchup_matchparen_nomode = "i",
+            matchup_matchparen_deferred = 1,
+          },
+        },
+      },
+    },
+  },
+}


### PR DESCRIPTION
## Summary
- Add vim-matchup plugin for enhanced `%` motion
- Extends bracket matching to support language constructs like `if/else/end`, `do/while`, HTML tags, etc.
- Based on AstroCommunity's `motion/vim-matchup` pack
- Disables matchparen highlighting in insert mode and enables deferred matching

Closes #98

## Test plan
- [ ] Open a Lua file and press `<Leader>m` on `if` to jump to matching `end`
- [ ] Verify `%` works on standard brackets `()`, `[]`, `{}`
- [ ] Verify matchparen highlighting does not appear in insert mode