### PR TITLE
feat(nix): add Google Cloud SDK

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -41,6 +41,7 @@
 
     # Cloud
     awscli2
+    google-cloud-sdk
   ];
 
   programs.home-manager.enable = true;


### PR DESCRIPTION
## Summary
- Add `google-cloud-sdk` package to home.nix for gcloud CLI access

## Test plan
- [ ] Run `hms` to apply the configuration
- [ ] Verify `gcloud --version` works