### PR TITLE
feat(git): enable push.autoSetupRemote

### DIFF
--- a/programs/git/default.nix
+++ b/programs/git/default.nix
@@ -32,6 +32,7 @@ in
       core.editor = "nvim";
       init.defaultBranch = "main";
       push.default = "simple";
+      push.autoSetupRemote = true;
       pull.rebase = true;
       rebase.autostash = true;
       diff.compactionHeuristic = true;


### PR DESCRIPTION
## Summary
- Enable `push.autoSetupRemote` in git config
- Automatically sets up upstream tracking branch when pushing a new branch
- Eliminates the need for `git push -u origin <branch>`

## Test plan
- [ ] Run `hms` to apply the configuration
- [ ] Create a new branch and push without `-u` flag to verify auto setup works