### PR TITLE
fix(nvim): map Ctrl+V to vsplit in snacks picker

### DIFF
--- a/programs/nvim/config/lua/plugins/snacks.lua
+++ b/programs/nvim/config/lua/plugins/snacks.lua
@@ -6,6 +6,7 @@ return {
         input = {
           keys = {
             ["<C-h>"] = { "edit_split", mode = { "i", "n" } },
+            ["<C-v>"] = { "edit_vsplit", mode = { "i", "n" } },
           },
         },
       },


### PR DESCRIPTION
## Summary
- Add `<C-v>` keybinding to snacks.nvim picker to open files in vertical split
- Previously, Ctrl+V in the picker input would paste instead of opening in vsplit

Closes #145

## Test plan
- [ ] Open Neovim and use a snacks picker (e.g., `<leader>ff`)
- [ ] Press `Ctrl+V` on a file to verify it opens in a vertical split