### PR TITLE
fix(ssh): disable deprecated enableDefaultConfig to suppress warning

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -64,6 +64,7 @@
 
   programs.ssh = {
     enable = true;
+    enableDefaultConfig = false;
     matchBlocks."*" = {
       addKeysToAgent = "yes";
     };


### PR DESCRIPTION
## Summary
- Set `programs.ssh.enableDefaultConfig = false` to suppress the deprecation warning
- The existing `matchBlocks."*"` already contains the desired default (`addKeysToAgent = "yes"`), so no behavior change

## Test plan
- [ ] Run `hms` and confirm the `programs.ssh` deprecation warning no longer appears