### PR TITLE
docs(claude): add rule to ask user before committing when stuck

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,7 @@ Apply the following labels:
 
 - When committing and creating a PR is the natural next step, do so without asking for confirmation
 - Always create a PR after committing unless the user explicitly says not to
+- When stuck (unsure how to proceed, repeating mistakes, or not making progress), do NOT commit or push. Instead, ask the user for guidance first
 
 ### Git Workflow
 


### PR DESCRIPTION
## Summary
- Add workflow rule: when stuck (unsure how to proceed, repeating mistakes, or not making progress), ask the user for guidance before committing or pushing

## Test plan
- [ ] Verify AGENTS.md contains the new rule in the Workflow section