### PR TITLE
fix(nvim): improve tab and winbar UI visibility with transparent background

### DIFF
--- a/programs/nvim/config/lua/plugins/astroui.lua
+++ b/programs/nvim/config/lua/plugins/astroui.lua
@@ -1,12 +1,3 @@
--- Catppuccin Mocha palette (hardcoded to avoid require timing issues)
-local surface0 = "#313244"
-local rosewater = "#f5e0dc"
-
-local function ul(extra)
-  local attrs = { underline = true, sp = surface0 }
-  return extra and vim.tbl_extend("force", attrs, extra) or attrs
-end
-
 ---@type LazySpec
 return {
   "AstroNvim/astroui",
@@ -15,25 +6,11 @@ return {
     opts.colorscheme = "catppuccin"
 
     if not opts.status then opts.status = {} end
-    if not opts.status.attributes then opts.status.attributes = {} end
-
-    opts.status.attributes.buffer_active = ul { bold = true }
-    opts.status.attributes.buffer_visible = ul()
-    opts.status.attributes.buffer = ul()
-    opts.status.attributes.buffer_active_close = ul()
-    opts.status.attributes.buffer_visible_close = ul()
-    opts.status.attributes.buffer_close = ul()
-    opts.status.attributes.buffer_active_path = ul()
-    opts.status.attributes.buffer_visible_path = ul()
-    opts.status.attributes.buffer_path = ul()
-    opts.status.attributes.tab_active = ul()
-    opts.status.attributes.tab = ul()
-    opts.status.attributes.tab_close = ul()
 
     local orig_colors = opts.status.colors
     opts.status.colors = function(colors)
       if type(orig_colors) == "function" then orig_colors(colors) end
-      colors.buffer_active_fg = rosewater
+      colors.buffer_active_fg = "#f5e0dc" -- rosewater
       return colors
     end
   end,

--- a/programs/nvim/config/lua/plugins/astroui.lua
+++ b/programs/nvim/config/lua/plugins/astroui.lua
@@ -1,35 +1,40 @@
+-- Catppuccin Mocha palette (hardcoded to avoid require timing issues)
+local surface0 = "#313244"
+local rosewater = "#f5e0dc"
+
+local function ul(extra)
+  local attrs = { underline = true, sp = surface0 }
+  return extra and vim.tbl_extend("force", attrs, extra) or attrs
+end
+
 ---@type LazySpec
 return {
   "AstroNvim/astroui",
   ---@type AstroUIOpts
   opts = function(_, opts)
-    local mocha = require("catppuccin.palettes").get_palette("mocha")
-    local function ul(extra)
-      local attrs = { underline = true, sp = mocha.surface0 }
-      return extra and vim.tbl_extend("force", attrs, extra) or attrs
+    opts.colorscheme = "catppuccin"
+
+    if not opts.status then opts.status = {} end
+    if not opts.status.attributes then opts.status.attributes = {} end
+
+    opts.status.attributes.buffer_active = ul { bold = true }
+    opts.status.attributes.buffer_visible = ul()
+    opts.status.attributes.buffer = ul()
+    opts.status.attributes.buffer_active_close = ul()
+    opts.status.attributes.buffer_visible_close = ul()
+    opts.status.attributes.buffer_close = ul()
+    opts.status.attributes.buffer_active_path = ul()
+    opts.status.attributes.buffer_visible_path = ul()
+    opts.status.attributes.buffer_path = ul()
+    opts.status.attributes.tab_active = ul()
+    opts.status.attributes.tab = ul()
+    opts.status.attributes.tab_close = ul()
+
+    local orig_colors = opts.status.colors
+    opts.status.colors = function(colors)
+      if type(orig_colors) == "function" then orig_colors(colors) end
+      colors.buffer_active_fg = rosewater
+      return colors
     end
-    return require("astrocore").extend_tbl(opts, {
-      colorscheme = "catppuccin",
-      status = {
-        attributes = {
-          buffer_active = ul { bold = true },
-          buffer_visible = ul(),
-          buffer = ul(),
-          buffer_active_close = ul(),
-          buffer_visible_close = ul(),
-          buffer_close = ul(),
-          buffer_active_path = ul(),
-          buffer_visible_path = ul(),
-          buffer_path = ul(),
-          tab_active = ul(),
-          tab = ul(),
-          tab_close = ul(),
-        },
-        colors = function(colors)
-          colors.buffer_active_fg = mocha.rosewater
-          return colors
-        end,
-      },
-    })
   end,
 }

--- a/programs/nvim/config/lua/plugins/astroui.lua
+++ b/programs/nvim/config/lua/plugins/astroui.lua
@@ -1,3 +1,8 @@
+-- Catppuccin Mocha palette
+local mantle = "#181825"
+local surface0 = "#313244"
+local rosewater = "#f5e0dc"
+
 ---@type LazySpec
 return {
   "AstroNvim/astroui",
@@ -6,11 +11,33 @@ return {
     opts.colorscheme = "catppuccin"
 
     if not opts.status then opts.status = {} end
+    if not opts.status.attributes then opts.status.attributes = {} end
+
+    -- Background colors on every tabline component for visual separation
+    opts.status.attributes.buffer_active = { bold = true, bg = surface0 }
+    opts.status.attributes.buffer_visible = { bg = mantle }
+    opts.status.attributes.buffer = { bg = mantle }
+    opts.status.attributes.buffer_active_close = { bg = surface0 }
+    opts.status.attributes.buffer_visible_close = { bg = mantle }
+    opts.status.attributes.buffer_close = { bg = mantle }
+    opts.status.attributes.buffer_active_path = { bg = surface0 }
+    opts.status.attributes.buffer_visible_path = { bg = mantle }
+    opts.status.attributes.buffer_path = { bg = mantle }
+    opts.status.attributes.tab_active = { bold = true, bg = surface0 }
+    opts.status.attributes.tab = { bg = mantle }
+    opts.status.attributes.tab_close = { bg = mantle }
 
     local orig_colors = opts.status.colors
     opts.status.colors = function(colors)
       if type(orig_colors) == "function" then orig_colors(colors) end
-      colors.buffer_active_fg = "#f5e0dc" -- rosewater
+      -- Fill / sidebar background
+      colors.tabline_bg = mantle
+      -- Active tab fg
+      colors.buffer_active_fg = rosewater
+      -- Tab page bg (used via include_bg=true)
+      colors.tab_active_bg = surface0
+      colors.tab_bg = mantle
+      colors.tab_close_bg = mantle
       return colors
     end
   end,

--- a/programs/nvim/config/lua/plugins/astroui.lua
+++ b/programs/nvim/config/lua/plugins/astroui.lua
@@ -4,11 +4,26 @@ return {
   ---@type AstroUIOpts
   opts = function(_, opts)
     local mocha = require("catppuccin.palettes").get_palette("mocha")
+    local function ul(extra)
+      local attrs = { underline = true, sp = mocha.surface0 }
+      return extra and vim.tbl_extend("force", attrs, extra) or attrs
+    end
     return require("astrocore").extend_tbl(opts, {
       colorscheme = "catppuccin",
       status = {
         attributes = {
-          buffer_active = { bold = true },
+          buffer_active = ul { bold = true },
+          buffer_visible = ul(),
+          buffer = ul(),
+          buffer_active_close = ul(),
+          buffer_visible_close = ul(),
+          buffer_close = ul(),
+          buffer_active_path = ul(),
+          buffer_visible_path = ul(),
+          buffer_path = ul(),
+          tab_active = ul(),
+          tab = ul(),
+          tab_close = ul(),
         },
         colors = function(colors)
           colors.buffer_active_fg = mocha.rosewater

--- a/programs/nvim/config/lua/plugins/astroui.lua
+++ b/programs/nvim/config/lua/plugins/astroui.lua
@@ -2,7 +2,19 @@
 return {
   "AstroNvim/astroui",
   ---@type AstroUIOpts
-  opts = {
-    colorscheme = "catppuccin",
-  },
+  opts = function(_, opts)
+    local mocha = require("catppuccin.palettes").get_palette("mocha")
+    return require("astrocore").extend_tbl(opts, {
+      colorscheme = "catppuccin",
+      status = {
+        attributes = {
+          buffer_active = { bold = true },
+        },
+        colors = function(colors)
+          colors.buffer_active_fg = mocha.rosewater
+          return colors
+        end,
+      },
+    })
+  end,
 }

--- a/programs/nvim/config/lua/plugins/colorscheme.lua
+++ b/programs/nvim/config/lua/plugins/colorscheme.lua
@@ -17,8 +17,8 @@ return {
           FloatBorder = { bg = "NONE" },
           FloatTitle = { bg = "NONE" },
           TabLineFill = { bg = "NONE", underline = true, sp = colors.surface0 },
-          TabLine = { fg = colors.overlay0, bg = "NONE" },
-          TabLineSel = { fg = colors.rosewater, bg = "NONE", bold = true },
+          TabLine = { fg = colors.overlay0, bg = "NONE", underline = true, sp = colors.surface0 },
+          TabLineSel = { fg = colors.rosewater, bg = "NONE", bold = true, underline = true, sp = colors.surface0 },
         }
       end,
     },

--- a/programs/nvim/config/lua/plugins/colorscheme.lua
+++ b/programs/nvim/config/lua/plugins/colorscheme.lua
@@ -16,9 +16,6 @@ return {
           NormalFloat = { bg = "NONE" },
           FloatBorder = { bg = "NONE" },
           FloatTitle = { bg = "NONE" },
-          TabLineFill = { bg = "NONE", underline = true, sp = colors.surface0 },
-          TabLine = { fg = colors.overlay0, bg = "NONE", underline = true, sp = colors.surface0 },
-          TabLineSel = { fg = colors.rosewater, bg = "NONE", bold = true, underline = true, sp = colors.surface0 },
         }
       end,
     },

--- a/programs/nvim/config/lua/plugins/colorscheme.lua
+++ b/programs/nvim/config/lua/plugins/colorscheme.lua
@@ -16,6 +16,9 @@ return {
           NormalFloat = { bg = "NONE" },
           FloatBorder = { bg = "NONE" },
           FloatTitle = { bg = "NONE" },
+          TabLineFill = { bg = "NONE", underline = true, sp = colors.surface0 },
+          TabLine = { fg = colors.overlay0, bg = "NONE" },
+          TabLineSel = { fg = colors.rosewater, bg = "NONE", bold = true },
         }
       end,
     },

--- a/programs/nvim/config/lua/plugins/heirline.lua
+++ b/programs/nvim/config/lua/plugins/heirline.lua
@@ -32,7 +32,6 @@ return {
           filetype = false,
           file_read_only = false,
           hl = status.hl.get_attributes("winbarnc", true),
-          surround = true,
           update = "BufEnter",
         }),
       },

--- a/programs/nvim/config/lua/plugins/heirline.lua
+++ b/programs/nvim/config/lua/plugins/heirline.lua
@@ -1,0 +1,9 @@
+return {
+  "rebelot/heirline.nvim",
+  opts = function(_, opts)
+    if opts.tabline then
+      local mocha = require("catppuccin.palettes").get_palette("mocha")
+      opts.tabline.hl = { underline = true, sp = mocha.surface0 }
+    end
+  end,
+}

--- a/programs/nvim/config/lua/plugins/heirline.lua
+++ b/programs/nvim/config/lua/plugins/heirline.lua
@@ -10,5 +10,37 @@ return {
     if opts.tabline then
       opts.tabline.hl = { bg = mantle }
     end
+
+    -- Enable surround on winbar for better visibility
+    local status = require("astroui.status")
+    opts.winbar = {
+      init = function(self)
+        self.bufnr = vim.api.nvim_get_current_buf()
+      end,
+      fallthrough = false,
+      { -- inactive winbar
+        condition = function()
+          return not status.condition.is_active()
+        end,
+        status.component.separated_path(),
+        status.component.file_info({
+          file_icon = {
+            hl = status.hl.file_icon("winbar"),
+            padding = { left = 0 },
+          },
+          filename = {},
+          filetype = false,
+          file_read_only = false,
+          hl = status.hl.get_attributes("winbarnc", true),
+          surround = true,
+          update = "BufEnter",
+        }),
+      },
+      { -- active winbar
+        status.component.breadcrumbs({
+          hl = status.hl.get_attributes("winbar", true),
+        }),
+      },
+    }
   end,
 }

--- a/programs/nvim/config/lua/plugins/heirline.lua
+++ b/programs/nvim/config/lua/plugins/heirline.lua
@@ -1,21 +1,14 @@
+-- Catppuccin Mocha palette
+local mantle = "#181825"
+local surface0 = "#313244"
+
 return {
   "rebelot/heirline.nvim",
   opts = function(_, opts)
-    -- Set underline on tabline root so all children inherit it
+    -- Set bg on tabline root so file icons (which don't use get_attributes)
+    -- inherit it via heirline's hl merge chain
     if opts.tabline then
-      opts.tabline.hl = { underline = true, sp = "#313244" }
-    end
-
-    -- Monkey-patch eval_hl to force sp on every underlined highlight.
-    -- This bypasses any inheritance/merge issues: heirline's final
-    -- highlight creation always gets the correct sp color.
-    local hi = require("heirline.highlights")
-    local orig_eval_hl = hi.eval_hl
-    function hi.eval_hl(hl)
-      if type(hl) == "table" and hl.underline then
-        hl = vim.tbl_extend("force", hl, { sp = "#313244" })
-      end
-      return orig_eval_hl(hl)
+      opts.tabline.hl = { bg = mantle }
     end
   end,
 }

--- a/programs/nvim/config/lua/plugins/heirline.lua
+++ b/programs/nvim/config/lua/plugins/heirline.lua
@@ -2,8 +2,7 @@ return {
   "rebelot/heirline.nvim",
   opts = function(_, opts)
     if opts.tabline then
-      local mocha = require("catppuccin.palettes").get_palette("mocha")
-      opts.tabline.hl = { underline = true, sp = mocha.surface0 }
+      opts.tabline.hl = { underline = true, sp = "#313244" }
     end
   end,
 }

--- a/programs/nvim/config/lua/plugins/heirline.lua
+++ b/programs/nvim/config/lua/plugins/heirline.lua
@@ -1,8 +1,21 @@
 return {
   "rebelot/heirline.nvim",
   opts = function(_, opts)
+    -- Set underline on tabline root so all children inherit it
     if opts.tabline then
       opts.tabline.hl = { underline = true, sp = "#313244" }
+    end
+
+    -- Monkey-patch eval_hl to force sp on every underlined highlight.
+    -- This bypasses any inheritance/merge issues: heirline's final
+    -- highlight creation always gets the correct sp color.
+    local hi = require("heirline.highlights")
+    local orig_eval_hl = hi.eval_hl
+    function hi.eval_hl(hl)
+      if type(hl) == "table" and hl.underline then
+        hl = vim.tbl_extend("force", hl, { sp = "#313244" })
+      end
+      return orig_eval_hl(hl)
     end
   end,
 }


### PR DESCRIPTION
## Summary
- Set explicit background colors on all tabline components (buffer tabs, tab pages, close buttons) for visual separation against transparent terminal backgrounds
- Set tabline root `hl` in heirline so file icons inherit the background via heirline's hl merge chain
- Enable `surround` on the inactive winbar's `file_info` component for better visibility

## Test plan
- [ ] Open Neovim with transparent terminal background
- [ ] Verify buffer tabs have visible background colors
- [ ] Verify active/inactive/visible buffer states are visually distinguishable
- [ ] Verify tab pages and close buttons have appropriate backgrounds
- [ ] Verify inactive winbar file info has surround enabled
- [ ] Split windows and confirm inactive winbar is visible