### PR TITLE
feat(nvim): configure Snacks dashboard with custom header

### DIFF
--- a/programs/nvim/config/lua/plugins/snacks.lua
+++ b/programs/nvim/config/lua/plugins/snacks.lua
@@ -1,6 +1,27 @@
 return {
   "folke/snacks.nvim",
   opts = {
+    dashboard = {
+      preset = {
+        header = table.concat({
+          "                                                     ",
+          "  ███╗   ██╗███████╗ ██████╗ ██╗   ██╗██╗███╗   ███╗ ",
+          "  ████╗  ██║██╔════╝██╔═══██╗██║   ██║██║████╗ ████║ ",
+          "  ██╔██╗ ██║█████╗  ██║   ██║██║   ██║██║██╔████╔██║ ",
+          "  ██║╚██╗██║██╔══╝  ██║   ██║╚██╗ ██╔╝██║██║╚██╔╝██║ ",
+          "  ██║ ╚████║███████╗╚██████╔╝ ╚████╔╝ ██║██║ ╚═╝ ██║ ",
+          "  ╚═╝  ╚═══╝╚══════╝ ╚═════╝   ╚═══╝  ╚═╝╚═╝     ╚═╝ ",
+          "                                                     ",
+        }, "\n"),
+        keys = {
+          { icon = " ", key = "f", desc = "Find File", action = "<Leader>ff" },
+          { icon = " ", key = "g", desc = "Find Text", action = "<Leader>fg" },
+          { icon = " ", key = "r", desc = "Recent Files", action = "<Leader>fo" },
+          { icon = " ", key = "e", desc = "New File", action = ":ene | startinsert" },
+          { icon = " ", key = "q", desc = "Quit", action = ":qa" },
+        },
+      },
+    },
     picker = {
       win = {
         input = {


### PR DESCRIPTION
## Summary

- Replace the default AstroNvim "ASTRO NVIM" dashboard header with the NEOVIM ASCII art from the old alpha-nvim config
- Update dashboard action keys to match the current custom keybindings (`<Leader>ff` for find files, `<Leader>fg` for grep, `<Leader>fo` for recent files)

Part of #94

## Test plan

- [ ] Open Neovim without arguments and verify the NEOVIM ASCII art header is displayed
- [ ] Verify each dashboard key (f, g, r, e, q) triggers the correct action