### PR TITLE
feat(nvim): add nvim-autopairs TeX dollar sign custom rules

### DIFF
--- a/programs/nvim/config/lua/plugins/autopairs.lua
+++ b/programs/nvim/config/lua/plugins/autopairs.lua
@@ -1,0 +1,17 @@
+return {
+  "windwp/nvim-autopairs",
+  config = function(plugin, opts)
+    require("astronvim.plugins.configs.nvim-autopairs")(plugin, opts)
+
+    local Rule = require("nvim-autopairs.rule")
+    local cond = require("nvim-autopairs.conds")
+    local npairs = require("nvim-autopairs")
+
+    npairs.add_rules({
+      Rule("$", "$", { "tex", "latex", "plaintex", "markdown" })
+        :with_pair(cond.not_after_regex("%%"))
+        :with_move(cond.after_text("$"))
+        :with_del(cond.done()),
+    })
+  end,
+}


### PR DESCRIPTION
## Summary

- Add LaTeX `$...$` auto-pairing rules for tex, latex, plaintex, and markdown filetypes
- Disable pairing after `%%` (LaTeX comments)
- Support auto-deletion and cursor movement for paired `$`

Part of #94

## Test plan

- [ ] Open a `.tex` file and type `$` — verify it auto-pairs to `$|$`
- [ ] Type `%%$` — verify no closing `$` is inserted
- [ ] With cursor at `$|$`, press backspace — verify both `$` are deleted
- [ ] With cursor at `$text|$`, type `$` — verify cursor moves past the closing `$`