### PR TITLE
feat(nvim): extend LuaSnip JS/TS with JSX/TSX snippets

### DIFF
--- a/programs/nvim/config/lua/plugins/luasnip.lua
+++ b/programs/nvim/config/lua/plugins/luasnip.lua
@@ -1,0 +1,8 @@
+return {
+  "L3MON4D3/LuaSnip",
+  config = function(plugin, opts)
+    require("astronvim.plugins.configs.luasnip")(plugin, opts)
+    require("luasnip").filetype_extend("javascript", { "javascriptreact" })
+    require("luasnip").filetype_extend("typescript", { "typescriptreact" })
+  end,
+}


### PR DESCRIPTION
## Summary

- Extend JavaScript filetype with JavaScriptReact snippets via LuaSnip's `filetype_extend`
- Extend TypeScript filetype with TypeScriptReact snippets similarly
- friendly-snippets integration is already handled by AstroNvim defaults

Part of #94

## Test plan

- [ ] Open a `.js` file and verify JSX snippets (e.g., `rfc`) are available in completion
- [ ] Open a `.ts` file and verify TSX snippets are available in completion