### PR TITLE
fix(nvim): clean up remaining default LSP keymaps

### DIFF
--- a/programs/nvim/config/lua/plugins/mappings.lua
+++ b/programs/nvim/config/lua/plugins/mappings.lua
@@ -216,8 +216,8 @@ return {
             cond = "textDocument/hover",
           },
           ["<Leader>;s"] = {
-            function() require("aerial").toggle() end,
-            desc = "Symbols outline",
+            function() Snacks.picker.lsp_symbols() end,
+            desc = "Document symbols",
           },
           ["<Leader>;H"] = {
             function() vim.lsp.buf.signature_help() end,
@@ -255,8 +255,8 @@ return {
             desc = "Workspace symbols",
           },
           ["<Leader>;o"] = {
-            function() Snacks.picker.lsp_symbols() end,
-            desc = "Document symbols",
+            function() require("aerial").toggle() end,
+            desc = "Symbols outline",
           },
         },
         v = {

--- a/programs/nvim/config/lua/plugins/mappings.lua
+++ b/programs/nvim/config/lua/plugins/mappings.lua
@@ -216,8 +216,8 @@ return {
             cond = "textDocument/hover",
           },
           ["<Leader>;s"] = {
-            function() Snacks.picker.lsp_symbols() end,
-            desc = "Document symbols",
+            function() require("aerial").toggle() end,
+            desc = "Symbols outline",
           },
           ["<Leader>;H"] = {
             function() vim.lsp.buf.signature_help() end,
@@ -255,8 +255,8 @@ return {
             desc = "Workspace symbols",
           },
           ["<Leader>;o"] = {
-            function() require("aerial").toggle() end,
-            desc = "Symbols outline",
+            function() Snacks.picker.lsp_symbols() end,
+            desc = "Document symbols",
           },
         },
         v = {

--- a/programs/nvim/config/lua/plugins/mappings.lua
+++ b/programs/nvim/config/lua/plugins/mappings.lua
@@ -49,6 +49,7 @@ return {
           ["grn"] = false,
           ["grr"] = false,
           ["grt"] = false,
+          ["gl"] = false,
           ["gy"] = false,
           ["K"] = false,
 
@@ -215,6 +216,10 @@ return {
             cond = "textDocument/hover",
           },
           ["<Leader>;s"] = {
+            function() Snacks.picker.lsp_symbols() end,
+            desc = "Document symbols",
+          },
+          ["<Leader>;H"] = {
             function() vim.lsp.buf.signature_help() end,
             desc = "Signature help",
             cond = "textDocument/signatureHelp",


### PR DESCRIPTION
## Summary

- Disable `gl` (line diagnostics) which duplicates `<Leader>;n`
- Reassign `<Leader>;s` from signature help to document symbols picker
- Add `<Leader>;H` for signature help
- Keep `<Leader>;o` (symbols outline), `<Leader>;S` (workspace symbols) unchanged

Closes #103

## Test plan

- [ ] Open an LSP-enabled file and verify `gl` is disabled
- [ ] Verify `<Leader>;s` opens document symbols picker
- [ ] Verify `<Leader>;S` opens workspace symbols picker
- [ ] Verify `<Leader>;o` toggles symbols outline (aerial)
- [ ] Verify `<Leader>;H` shows signature help
- [ ] Verify `<Leader>;n` still works for line diagnostics