### PR TITLE
feat(nvim): add sidekick keymaps for diagnostics and diagnostics_all

### DIFF
--- a/programs/nvim/config/lua/plugins/sidekick.lua
+++ b/programs/nvim/config/lua/plugins/sidekick.lua
@@ -44,6 +44,16 @@ return {
       desc = "Send Visual Selection",
     },
     {
+      "<leader>sd",
+      function() require("sidekick.cli").ask({ prompt = "diagnostics", submit = true }) end,
+      desc = "Send Diagnostics",
+    },
+    {
+      "<leader>sD",
+      function() require("sidekick.cli").ask({ prompt = "diagnostics_all", submit = true }) end,
+      desc = "Send All Diagnostics",
+    },
+    {
       "<leader>sp",
       function() require("sidekick.cli").prompt() end,
       mode = { "n", "v" },

--- a/programs/nvim/config/lua/plugins/sidekick.lua
+++ b/programs/nvim/config/lua/plugins/sidekick.lua
@@ -45,12 +45,12 @@ return {
     },
     {
       "<leader>sd",
-      function() require("sidekick.cli").ask({ prompt = "diagnostics", submit = true }) end,
+      function() require("sidekick.cli").send({ msg = "{diagnostics}" }) end,
       desc = "Send Diagnostics",
     },
     {
       "<leader>sD",
-      function() require("sidekick.cli").ask({ prompt = "diagnostics_all", submit = true }) end,
+      function() require("sidekick.cli").send({ msg = "{diagnostics_all}" }) end,
       desc = "Send All Diagnostics",
     },
     {


### PR DESCRIPTION
## Summary
- Add `<leader>sd` keymap to send current file diagnostics to sidekick CLI
- Add `<leader>sD` keymap to send all diagnostics to sidekick CLI

## Test plan
- [ ] Open Neovim with a file that has diagnostics
- [ ] Press `<leader>sd` and verify diagnostics are sent to the CLI
- [ ] Press `<leader>sD` and verify all diagnostics are sent to the CLI