### PR TITLE
feat(nvim): add border to Lazy plugin manager window

### DIFF
--- a/programs/nvim/config/lua/setup.lua
+++ b/programs/nvim/config/lua/setup.lua
@@ -18,7 +18,7 @@ require("lazy").setup({
   { import = "plugins.lang" },
 } --[[@as LazySpec]], {
   -- Configure any other `lazy.nvim` configuration options here
-  ui = { backdrop = 100 },
+  ui = { backdrop = 100, border = "rounded" },
   performance = {
     rtp = {
       -- disable some rtp plugins, add more to your liking


### PR DESCRIPTION
## Summary
- Add `border = "rounded"` to Lazy.nvim UI config for a rounded border on the plugin manager window

## Test plan
- [ ] Open Neovim and run `:Lazy` to confirm the window has a rounded border