### PR TITLE
feat(nvim): add border to Mason window

### DIFF
--- a/programs/nvim/config/lua/plugins/mason.lua
+++ b/programs/nvim/config/lua/plugins/mason.lua
@@ -1,0 +1,8 @@
+return {
+  "williamboman/mason.nvim",
+  opts = {
+    ui = {
+      border = "rounded",
+    },
+  },
+}


### PR DESCRIPTION
## Summary
- Add `border = "rounded"` to Mason UI config for a rounded border on the Mason window

## Test plan
- [ ] Open Neovim and run `:Mason` to confirm the window has a rounded border