### PR TITLE
refactor(nix): merge repeated attribute keys in home.nix

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -9,7 +9,7 @@
   ];
 
   home = {
-    username = username;
+    inherit username;
     homeDirectory = "/home/${username}";
     stateVersion = "26.05";
 

--- a/home.nix
+++ b/home.nix
@@ -8,70 +8,74 @@
     ./programs/claude
   ];
 
-  home.username = username;
-  home.homeDirectory = "/home/${username}";
-  home.stateVersion = "26.05";
+  home = {
+    username = username;
+    homeDirectory = "/home/${username}";
+    stateVersion = "26.05";
 
-  home.packages = with pkgs; [
-    # Version control
-    gh
-    ghq
+    packages = with pkgs; [
+      # Version control
+      gh
+      ghq
 
-    # Languages & runtimes
-    go
-    lua
-    python3
-    ruby
-    deno
-    bun
+      # Languages & runtimes
+      go
+      lua
+      python3
+      ruby
+      deno
+      bun
 
-    # Package managers
-    uv
+      # Package managers
+      uv
 
-    # Nix tools
-    nil
-    statix
-    deadnix
+      # Nix tools
+      nil
+      statix
+      deadnix
 
-    # CLI tools
-    ripgrep
-    fzf
-    yq-go
-    jq
-    curl
-    zip
-    unzip
-    gnupg
-    claude-code
+      # CLI tools
+      ripgrep
+      fzf
+      yq-go
+      jq
+      curl
+      zip
+      unzip
+      gnupg
+      claude-code
 
-    # Cloud
-    awscli2
-    google-cloud-sdk
-  ];
-
-  programs.home-manager.enable = true;
-
-  programs.direnv = {
-    enable = true;
-    enableZshIntegration = true;
-    nix-direnv.enable = true;
+      # Cloud
+      awscli2
+      google-cloud-sdk
+    ];
   };
 
-  programs.zoxide = {
-    enable = true;
-    enableZshIntegration = true;
-  };
+  programs = {
+    home-manager.enable = true;
 
-  programs.fzf = {
-    enable = true;
-    enableZshIntegration = true;
-  };
+    direnv = {
+      enable = true;
+      enableZshIntegration = true;
+      nix-direnv.enable = true;
+    };
 
-  programs.ssh = {
-    enable = true;
-    enableDefaultConfig = false;
-    matchBlocks."*" = {
-      addKeysToAgent = "yes";
+    zoxide = {
+      enable = true;
+      enableZshIntegration = true;
+    };
+
+    fzf = {
+      enable = true;
+      enableZshIntegration = true;
+    };
+
+    ssh = {
+      enable = true;
+      enableDefaultConfig = false;
+      matchBlocks."*" = {
+        addKeysToAgent = "yes";
+      };
     };
   };
 


### PR DESCRIPTION
## Summary
- Merge repeated `home` key assignments into a single `home = { ... }` attribute set
- Merge repeated `programs` key assignments into a single `programs = { ... }` attribute set
- Resolves statix warnings about repeated keys

## Test plan
- [ ] Verify `statix check home.nix` no longer reports repeated key warnings
- [ ] Verify `hms` applies successfully