### PR TITLE
feat(wezterm): add basic Home Manager setup

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -6,6 +6,7 @@
     ./programs/git
     ./programs/nvim
     ./programs/claude
+    ./programs/wezterm
   ];
 
   home = {

--- a/programs/wezterm/default.nix
+++ b/programs/wezterm/default.nix
@@ -1,0 +1,12 @@
+{ ... }:
+
+{
+  programs.wezterm = {
+    enable = true;
+    enableZshIntegration = true;
+    extraConfig = ''
+      local config = wezterm.config_builder()
+      return config
+    '';
+  };
+}


### PR DESCRIPTION
## Summary
- Add `programs/wezterm/default.nix` module with `programs.wezterm` enabled, Zsh integration, and minimal `config_builder()` config
- Import the new module in `home.nix`

Closes #165

## Test plan
- [x] `hms` applies successfully
- [x] WezTerm package is installed