### PR TITLE
feat(wezterm): deploy config to Windows side on WSL

### DIFF
--- a/programs/wezterm/default.nix
+++ b/programs/wezterm/default.nix
@@ -1,4 +1,4 @@
-{ ... }:
+{ config, lib, isWSL, ... }:
 
 {
   programs.wezterm = {
@@ -9,4 +9,18 @@
       return config
     '';
   };
+
+  home.activation.deployWeztermToWindows = lib.mkIf isWSL (
+    lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      win_user=$(cmd.exe /c "echo %USERNAME%" 2>/dev/null | tr -d '\r')
+      if [ -n "$win_user" ]; then
+        win_config="/mnt/c/Users/$win_user/.config/wezterm"
+        mkdir -p "$win_config"
+        cp -rT "${config.home.homeDirectory}/.config/wezterm" "$win_config"
+        echo "Deployed WezTerm config to $win_config"
+      else
+        echo "Warning: Could not detect Windows username, skipping WezTerm Windows deployment" >&2
+      fi
+    ''
+  );
 }

--- a/programs/wezterm/default.nix
+++ b/programs/wezterm/default.nix
@@ -12,11 +12,11 @@
 
   home.activation.deployWeztermToWindows = lib.mkIf isWSL (
     lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-      win_user=$(cmd.exe /c "echo %USERNAME%" 2>/dev/null | tr -d '\r')
+      win_user=$(/mnt/c/Windows/System32/cmd.exe /c "echo %USERNAME%" 2>/dev/null | tr -d '\r')
       if [ -n "$win_user" ]; then
         win_config="/mnt/c/Users/$win_user/.config/wezterm"
         mkdir -p "$win_config"
-        cp -rT "${config.home.homeDirectory}/.config/wezterm" "$win_config"
+        cp -rTL "${config.home.homeDirectory}/.config/wezterm" "$win_config"
         echo "Deployed WezTerm config to $win_config"
       else
         echo "Warning: Could not detect Windows username, skipping WezTerm Windows deployment" >&2


### PR DESCRIPTION
## Summary
- Add `home.activation.deployWeztermToWindows` to `programs/wezterm/default.nix`
- On WSL, the activation script copies WezTerm config from `~/.config/wezterm/` to `/mnt/c/Users/<username>/.config/wezterm/` during `hms`
- Auto-detects Windows username via `cmd.exe` and skips gracefully if detection fails
- Guarded by `lib.mkIf isWSL` so it's a no-op on native Linux
- Closes #165 (task 2)

## Test plan
- [x] Run `hms` — activation completes without errors
- [ ] On WSL: verify files appear at `/mnt/c/Users/<username>/.config/wezterm/`
- [ ] On WSL: verify WezTerm picks up the config