### PR TITLE
feat(wezterm): add font and appearance configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ dotfiles/
 
 ### Font
 
-Install [UbuntuSansMono Nerd Font](https://www.nerdfonts.com/font-downloads) (`UbuntuSansMono Nerd Font Mono`).
+Install [UbuntuSans Nerd Font](https://www.nerdfonts.com/font-downloads) (`UbuntuSansMono Nerd Font Mono`).
 
 ### WSL
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ dotfiles/
 
 ### Font
 
-Install [UbuntuSans Nerd Font](https://www.nerdfonts.com/font-downloads) (`UbuntuSansMono Nerd Font Mono`).
+Install [UbuntuSansMono Nerd Font](https://www.nerdfonts.com/font-downloads) (`UbuntuSansMono Nerd Font Mono`).
 
 ### WSL
 

--- a/programs/wezterm/config/appearance.lua
+++ b/programs/wezterm/config/appearance.lua
@@ -6,9 +6,8 @@ function M.apply_to_config(config)
   -- Hide the title bar, keep the resizable border
   config.window_decorations = "RESIZE"
 
-  -- Show the tab bar only when there are multiple tabs, using the retro style
+  -- Always show the tab bar using the retro style
   config.enable_tab_bar = true
-  -- config.hide_tab_bar_if_only_one_tab = true
   config.use_fancy_tab_bar = false
 
   -- Dim inactive panes to visually distinguish the active one

--- a/programs/wezterm/config/appearance.lua
+++ b/programs/wezterm/config/appearance.lua
@@ -2,10 +2,16 @@ local M = {}
 
 function M.apply_to_config(config)
   config.color_scheme = "Catppuccin Mocha"
+
+  -- Hide the title bar, keep the resizable border
   config.window_decorations = "RESIZE"
+
+  -- Show the tab bar only when there are multiple tabs, using the retro style
   config.enable_tab_bar = true
-  config.hide_tab_bar_if_only_one_tab = true
+  -- config.hide_tab_bar_if_only_one_tab = true
   config.use_fancy_tab_bar = false
+
+  -- Dim inactive panes to visually distinguish the active one
   config.inactive_pane_hsb = {
     saturation = 0.8,
     brightness = 0.7,

--- a/programs/wezterm/config/appearance.lua
+++ b/programs/wezterm/config/appearance.lua
@@ -1,0 +1,15 @@
+local M = {}
+
+function M.apply_to_config(config)
+  config.color_scheme = "Catppuccin Mocha"
+  config.window_decorations = "RESIZE"
+  config.enable_tab_bar = true
+  config.hide_tab_bar_if_only_one_tab = true
+  config.use_fancy_tab_bar = false
+  config.inactive_pane_hsb = {
+    saturation = 0.8,
+    brightness = 0.7,
+  }
+end
+
+return M

--- a/programs/wezterm/config/font.lua
+++ b/programs/wezterm/config/font.lua
@@ -5,6 +5,8 @@ local M = {}
 function M.apply_to_config(config)
   config.font = wezterm.font("UbuntuSansMono Nerd Font Mono")
   config.font_size = 13.0
+  config.freetype_load_target = "Light"
+  config.freetype_render_target = "HorizontalLcd"
 end
 
 return M

--- a/programs/wezterm/config/font.lua
+++ b/programs/wezterm/config/font.lua
@@ -3,7 +3,7 @@ local wezterm = require("wezterm")
 local M = {}
 
 function M.apply_to_config(config)
-  config.font = wezterm.font("UbuntuSans Nerd Font")
+  config.font = wezterm.font("UbuntuSansMono Nerd Font Mono")
   config.font_size = 13.0
 end
 

--- a/programs/wezterm/config/font.lua
+++ b/programs/wezterm/config/font.lua
@@ -1,0 +1,10 @@
+local wezterm = require("wezterm")
+
+local M = {}
+
+function M.apply_to_config(config)
+  config.font = wezterm.font("UbuntuSans Nerd Font")
+  config.font_size = 13.0
+end
+
+return M

--- a/programs/wezterm/config/font.lua
+++ b/programs/wezterm/config/font.lua
@@ -5,7 +5,10 @@ local M = {}
 function M.apply_to_config(config)
   config.font = wezterm.font("UbuntuSansMono Nerd Font Mono")
   config.font_size = 13.0
+
+  -- Light hinting for smoother glyph shapes
   config.freetype_load_target = "Light"
+  -- Subpixel anti-aliasing for sharper rendering on LCD displays
   config.freetype_render_target = "HorizontalLcd"
 end
 

--- a/programs/wezterm/default.nix
+++ b/programs/wezterm/default.nix
@@ -7,19 +7,15 @@
     extraConfig = ''
       local config = wezterm.config_builder()
 
-      require("font").apply_to_config(config)
-      require("appearance").apply_to_config(config)
+      require("config.font").apply_to_config(config)
+      require("config.appearance").apply_to_config(config)
 
       return config
     '';
   };
 
-  xdg.configFile = {
-    "wezterm/font.lua".source =
-      config.lib.file.mkOutOfStoreSymlink "${dotfilesDir}/programs/wezterm/config/font.lua";
-    "wezterm/appearance.lua".source =
-      config.lib.file.mkOutOfStoreSymlink "${dotfilesDir}/programs/wezterm/config/appearance.lua";
-  };
+  xdg.configFile."wezterm/config".source =
+    config.lib.file.mkOutOfStoreSymlink "${dotfilesDir}/programs/wezterm/config";
 
   home.activation.deployWeztermToWindows = lib.mkIf isWSL (
     lib.hm.dag.entryAfter [ "linkGeneration" ] ''

--- a/programs/wezterm/default.nix
+++ b/programs/wezterm/default.nix
@@ -1,4 +1,4 @@
-{ config, lib, isWSL, ... }:
+{ config, lib, isWSL, dotfilesDir, ... }:
 
 {
   programs.wezterm = {
@@ -6,17 +6,30 @@
     enableZshIntegration = true;
     extraConfig = ''
       local config = wezterm.config_builder()
+
+      require("font").apply_to_config(config)
+      require("appearance").apply_to_config(config)
+
       return config
     '';
   };
 
+  xdg.configFile = {
+    "wezterm/font.lua".source =
+      config.lib.file.mkOutOfStoreSymlink "${dotfilesDir}/programs/wezterm/config/font.lua";
+    "wezterm/appearance.lua".source =
+      config.lib.file.mkOutOfStoreSymlink "${dotfilesDir}/programs/wezterm/config/appearance.lua";
+  };
+
   home.activation.deployWeztermToWindows = lib.mkIf isWSL (
-    lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    lib.hm.dag.entryAfter [ "linkGeneration" ] ''
       win_user=$(/mnt/c/Windows/System32/cmd.exe /c "echo %USERNAME%" 2>/dev/null | tr -d '\r')
       if [ -n "$win_user" ]; then
         win_config="/mnt/c/Users/$win_user/.config/wezterm"
+        rm -rf "$win_config"
         mkdir -p "$win_config"
         cp -rTL "${config.home.homeDirectory}/.config/wezterm" "$win_config"
+        chmod -R u+w "$win_config"
         echo "Deployed WezTerm config to $win_config"
       else
         echo "Warning: Could not detect Windows username, skipping WezTerm Windows deployment" >&2


### PR DESCRIPTION
## Summary
- Add modular Lua config structure for WezTerm with `font.lua` and `appearance.lua` sub-modules
- Configure UbuntuSans Nerd Font (size 13) and Catppuccin Mocha color scheme
- Symlink Lua modules via `mkOutOfStoreSymlink` for live editing without re-running `hms`
- Fix Windows deployment activation to run after `linkGeneration` so all symlinks are resolved
- Fix read-only file issue on NTFS by cleaning destination before copy and setting write permissions

## Test plan
- [x] `hms` completes without errors
- [x] `~/.config/wezterm/` contains `wezterm.lua`, `font.lua` (symlink), `appearance.lua` (symlink)
- [x] Windows side `/mnt/c/Users/<username>/.config/wezterm/` has real copies of all three files
- [ ] Open WezTerm and verify UbuntuSans Nerd Font and Catppuccin Mocha are applied