### PR TITLE
feat(wezterm): add custom tab bar with pill-shaped active tabs

### DIFF
--- a/programs/wezterm/config/appearance.lua
+++ b/programs/wezterm/config/appearance.lua
@@ -10,6 +10,18 @@ function M.apply_to_config(config)
   config.enable_tab_bar = true
   config.use_fancy_tab_bar = false
 
+  -- Tab bar positioning and limits
+  config.tab_bar_at_bottom = true
+  config.tab_max_width = 30
+  config.show_new_tab_button_in_tab_bar = false
+
+  -- Tab bar colors (Catppuccin Mocha)
+  config.colors = {
+    tab_bar = {
+      background = "#181825", -- mantle
+    },
+  }
+
   -- Dim inactive panes to visually distinguish the active one
   config.inactive_pane_hsb = {
     saturation = 0.8,

--- a/programs/wezterm/config/appearance.lua
+++ b/programs/wezterm/config/appearance.lua
@@ -12,7 +12,7 @@ function M.apply_to_config(config)
 
   -- Tab bar positioning and limits
   config.tab_bar_at_bottom = true
-  config.tab_max_width = 30
+  config.tab_max_width = 50
   config.show_new_tab_button_in_tab_bar = false
 
   -- Tab bar colors (Catppuccin Mocha)

--- a/programs/wezterm/config/tab.lua
+++ b/programs/wezterm/config/tab.lua
@@ -1,4 +1,5 @@
 local wezterm = require("wezterm")
+local nf = wezterm.nerdfonts
 
 -- Catppuccin Mocha palette
 local colors = {
@@ -8,24 +9,24 @@ local colors = {
   tab_bar_bg = "#181825", -- mantle
 }
 
+-- Nerd Font half-circle glyphs for pill shape
+local LEFT_PILL = nf.ple_left_half_circle_thick
+local RIGHT_PILL = nf.ple_right_half_circle_thick
+
 -- Process name -> { icon, color }
 local process_icons = {
-  nvim = { icon = "", color = "#a6e3a1" }, -- green
-  vim = { icon = "", color = "#a6e3a1" },
-  docker = { icon = "", color = "#89b4fa" }, -- blue
-  ssh = { icon = "󰣀", color = "#f9e2af" }, -- yellow
-  claude = { icon = "󱜚", color = "#cba6f7" }, -- mauve
-  node = { icon = "", color = "#a6e3a1" },
-  python = { icon = "", color = "#f9e2af" },
-  ruby = { icon = "", color = "#f38ba8" }, -- red
-  go = { icon = "", color = "#89dceb" }, -- teal
-  cargo = { icon = "", color = "#fab387" }, -- peach
-  rust = { icon = "", color = "#fab387" },
+  nvim = { icon = nf.linux_neovim, color = "#a6e3a1" }, -- green
+  vim = { icon = nf.linux_neovim, color = "#a6e3a1" },
+  docker = { icon = nf.md_docker, color = "#89b4fa" }, -- blue
+  ssh = { icon = nf.md_lan, color = "#f9e2af" }, -- yellow
+  claude = { icon = nf.md_robot, color = "#cba6f7" }, -- mauve
+  node = { icon = nf.dev_nodejs_small, color = "#a6e3a1" },
+  python = { icon = nf.dev_python, color = "#f9e2af" },
+  ruby = { icon = nf.dev_ruby, color = "#f38ba8" }, -- red
+  go = { icon = nf.dev_go, color = "#89dceb" }, -- teal
+  cargo = { icon = nf.dev_rust, color = "#fab387" }, -- peach
+  rust = { icon = nf.dev_rust, color = "#fab387" },
 }
-
--- Nerd Font half-circle glyphs for pill shape
-local LEFT_PILL = ""
-local RIGHT_PILL = ""
 
 local function get_process_info(pane)
   local process_name = pane.foreground_process_name:match("([^/\\]+)$") or ""
@@ -33,7 +34,7 @@ local function get_process_info(pane)
   if info then
     return info.icon, info.color
   end
-  return "", colors.active_bg
+  return nf.dev_terminal, colors.active_bg
 end
 
 local function get_project_name(cwd_uri)
@@ -60,7 +61,7 @@ local function format_tab(tab, max_width)
   local zoom = ""
   for _, p in ipairs(tab.panes) do
     if p.is_zoomed then
-      zoom = " 󰍉"
+      zoom = " " .. nf.md_magnify
       break
     end
   end

--- a/programs/wezterm/config/tab.lua
+++ b/programs/wezterm/config/tab.lua
@@ -6,8 +6,8 @@ local LEFT_PILL = nf.ple_left_half_circle_thick
 local RIGHT_PILL = nf.ple_right_half_circle_thick
 
 -- Catppuccin Mocha tab colors
-local TAB_FG = "#1e1e2e" -- base (active tab text)
-local TAB_BG = "#181825" -- mantle (tab bar background)
+local TAB_FG = "#1e1e2e"          -- base (active tab text)
+local TAB_BG = "#181825"          -- mantle (tab bar background)
 local TAB_INACTIVE_FG = "#6c7086" -- overlay0 (inactive tab text)
 
 -- Process definitions: icon, color, and detection function.
@@ -83,16 +83,7 @@ local function format_tab(tab, max_width)
   local icon, icon_color = get_process_info(pane)
   local title = get_project_name(pane.current_working_dir) or "~"
 
-  -- Zoom indicator
-  local zoom = ""
-  for _, p in ipairs(tab.panes) do
-    if p.is_zoomed then
-      zoom = " " .. nf.md_magnify
-      break
-    end
-  end
-
-  local label = title .. zoom
+  local label = title
 
   -- Truncate if too long (account for pill glyphs + icon)
   local text_max = max_width - 6

--- a/programs/wezterm/config/tab.lua
+++ b/programs/wezterm/config/tab.lua
@@ -57,7 +57,7 @@ local function get_process_info(pane)
     end
   end
 
-  return nf.dev_terminal, colors.active_bg
+  return nf.dev_terminal, "#585b70" -- surface2
 end
 
 local function get_project_name(cwd_url)

--- a/programs/wezterm/config/tab.lua
+++ b/programs/wezterm/config/tab.lua
@@ -1,17 +1,14 @@
 local wezterm = require("wezterm")
 local nf = wezterm.nerdfonts
 
--- Catppuccin Mocha palette
-local colors = {
-  active_bg = "#89b4fa",  -- blue
-  active_fg = "#1e1e2e",  -- base
-  inactive_fg = "#6c7086", -- overlay0
-  tab_bar_bg = "#181825", -- mantle
-}
-
 -- Nerd Font half-circle glyphs for pill shape
 local LEFT_PILL = nf.ple_left_half_circle_thick
 local RIGHT_PILL = nf.ple_right_half_circle_thick
+
+-- Catppuccin Mocha tab colors
+local TAB_FG = "#1e1e2e" -- base (active tab text)
+local TAB_BG = "#181825" -- mantle (tab bar background)
+local TAB_INACTIVE_FG = "#6c7086" -- overlay0 (inactive tab text)
 
 -- Process definitions: icon, color, and detection function.
 -- Each detect() checks foreground_process_name and pane title.
@@ -106,23 +103,23 @@ local function format_tab(tab, max_width)
   if tab.is_active then
     return {
       { Foreground = { Color = icon_color } },
-      { Background = { Color = colors.tab_bar_bg } },
+      { Background = { Color = TAB_BG } },
       { Text = LEFT_PILL },
-      { Foreground = { Color = colors.active_fg } },
+      { Foreground = { Color = TAB_FG } },
       { Background = { Color = icon_color } },
       { Attribute = { Intensity = "Bold" } },
       { Text = " " .. icon .. " " .. label .. " " },
       { Foreground = { Color = icon_color } },
-      { Background = { Color = colors.tab_bar_bg } },
+      { Background = { Color = TAB_BG } },
       { Text = RIGHT_PILL },
     }
   else
     return {
       { Foreground = { Color = icon_color } },
-      { Background = { Color = colors.tab_bar_bg } },
+      { Background = { Color = TAB_BG } },
       { Text = "  " .. icon },
-      { Foreground = { Color = colors.inactive_fg } },
-      { Background = { Color = colors.tab_bar_bg } },
+      { Foreground = { Color = TAB_INACTIVE_FG } },
+      { Background = { Color = TAB_BG } },
       { Text = " " .. label .. "  " },
     }
   end

--- a/programs/wezterm/config/tab.lua
+++ b/programs/wezterm/config/tab.lua
@@ -115,10 +115,10 @@ local function format_tab(tab, max_width)
     return {
       { Foreground = { Color = icon_color } },
       { Background = { Color = colors.tab_bar_bg } },
-      { Text = " " .. icon },
+      { Text = "  " .. icon },
       { Foreground = { Color = colors.inactive_fg } },
       { Background = { Color = colors.tab_bar_bg } },
-      { Text = " " .. label .. " " },
+      { Text = " " .. label .. "  " },
     }
   end
 end

--- a/programs/wezterm/config/tab.lua
+++ b/programs/wezterm/config/tab.lua
@@ -103,17 +103,14 @@ local function format_tab(tab, max_width)
 
   if tab.is_active then
     return {
-      { Foreground = { Color = colors.active_bg } },
+      { Foreground = { Color = icon_color } },
       { Background = { Color = colors.tab_bar_bg } },
       { Text = LEFT_PILL },
       { Foreground = { Color = colors.active_fg } },
-      { Background = { Color = colors.active_bg } },
-      { Text = " " .. icon },
-      { Foreground = { Color = colors.active_fg } },
-      { Background = { Color = colors.active_bg } },
+      { Background = { Color = icon_color } },
       { Attribute = { Intensity = "Bold" } },
-      { Text = " " .. label .. " " },
-      { Foreground = { Color = colors.active_bg } },
+      { Text = " " .. icon .. " " .. label .. " " },
+      { Foreground = { Color = icon_color } },
       { Background = { Color = colors.tab_bar_bg } },
       { Text = RIGHT_PILL },
     }

--- a/programs/wezterm/config/tab.lua
+++ b/programs/wezterm/config/tab.lua
@@ -106,7 +106,7 @@ local function format_tab(tab, max_width)
       { Foreground = { Color = colors.active_bg } },
       { Background = { Color = colors.tab_bar_bg } },
       { Text = LEFT_PILL },
-      { Foreground = { Color = icon_color } },
+      { Foreground = { Color = colors.active_fg } },
       { Background = { Color = colors.active_bg } },
       { Text = " " .. icon },
       { Foreground = { Color = colors.active_fg } },

--- a/programs/wezterm/config/tab.lua
+++ b/programs/wezterm/config/tab.lua
@@ -5,10 +5,11 @@ local nf = wezterm.nerdfonts
 local LEFT_PILL = nf.ple_left_half_circle_thick
 local RIGHT_PILL = nf.ple_right_half_circle_thick
 
--- Catppuccin Mocha tab colors
-local TAB_FG = "#1e1e2e"          -- base (active tab text)
-local TAB_BG = "#181825"          -- mantle (tab bar background)
-local TAB_INACTIVE_FG = "#6c7086" -- overlay0 (inactive tab text)
+-- Colors from color scheme
+local scheme = wezterm.color.get_builtin_schemes()["Catppuccin Mocha"]
+local TAB_FG = scheme.background -- base
+local TAB_BG = scheme.tab_bar.background -- mantle
+local TAB_INACTIVE_FG = scheme.tab_bar.inactive_tab.fg_color
 
 -- Process definitions: icon, color, and detection function.
 -- Each detect() checks foreground_process_name and pane title.
@@ -16,32 +17,32 @@ local TAB_INACTIVE_FG = "#6c7086" -- overlay0 (inactive tab text)
 local processes = {
   default = {
     icon = nf.dev_terminal,
-    color = "#585b70", -- surface2
+    color = scheme.brights[1], -- surface2
   },
   {
     icon = nf.linux_neovim,
-    color = "#a6e3a1", -- green
+    color = scheme.ansi[3], -- green
     detect = function(name, title)
       return name == "nvim" or name == "vim" or title:find("[Nn]vim") ~= nil
     end,
   },
   {
     icon = nf.md_docker,
-    color = "#89b4fa", -- blue
+    color = scheme.ansi[5], -- blue
     detect = function(name, title)
       return name == "docker" or title:find("[Dd]ocker") ~= nil
     end,
   },
   {
     icon = nf.md_lan,
-    color = "#f9e2af", -- yellow
+    color = scheme.ansi[4], -- yellow
     detect = function(name, title)
       return name == "ssh" or title:find("[Ss][Ss][Hh]") ~= nil
     end,
   },
   {
     icon = nf.md_robot,
-    color = "#D97757", -- claude orange
+    color = "#D97757", -- claude orange (not in scheme)
     detect = function(name, title)
       return name == "claude" or title:find("[Cc]laude") ~= nil
     end,

--- a/programs/wezterm/config/tab.lua
+++ b/programs/wezterm/config/tab.lua
@@ -1,0 +1,109 @@
+local wezterm = require("wezterm")
+
+-- Catppuccin Mocha palette
+local colors = {
+  active_bg = "#89b4fa", -- blue
+  active_fg = "#1e1e2e", -- base
+  inactive_fg = "#6c7086", -- overlay0
+  tab_bar_bg = "#181825", -- mantle
+}
+
+-- Process name -> { icon, color }
+local process_icons = {
+  nvim = { icon = "", color = "#a6e3a1" }, -- green
+  vim = { icon = "", color = "#a6e3a1" },
+  docker = { icon = "", color = "#89b4fa" }, -- blue
+  ssh = { icon = "󰣀", color = "#f9e2af" }, -- yellow
+  claude = { icon = "󱜚", color = "#cba6f7" }, -- mauve
+  node = { icon = "", color = "#a6e3a1" },
+  python = { icon = "", color = "#f9e2af" },
+  ruby = { icon = "", color = "#f38ba8" }, -- red
+  go = { icon = "", color = "#89dceb" }, -- teal
+  cargo = { icon = "", color = "#fab387" }, -- peach
+  rust = { icon = "", color = "#fab387" },
+}
+
+-- Nerd Font half-circle glyphs for pill shape
+local LEFT_PILL = ""
+local RIGHT_PILL = ""
+
+local function get_process_info(pane)
+  local process_name = pane.foreground_process_name:match("([^/\\]+)$") or ""
+  local info = process_icons[process_name]
+  if info then
+    return info.icon, info.color
+  end
+  return "", colors.active_bg
+end
+
+local function get_project_name(cwd_uri)
+  if not cwd_uri then
+    return nil
+  end
+
+  local cwd = cwd_uri:match("^file://[^/]*(/.*)") or cwd_uri
+  -- Match src/github.com/<org>/<project>
+  local project = cwd:match("/src/github%.com/[^/]+/([^/]+)")
+  if project then
+    return project
+  end
+  -- Fallback: last directory component
+  return cwd:match("([^/]+)/?$")
+end
+
+local function format_tab(tab, max_width)
+  local pane = tab.active_pane
+  local icon, icon_color = get_process_info(pane)
+  local title = get_project_name(pane.current_working_dir) or "~"
+
+  -- Zoom indicator
+  local zoom = ""
+  for _, p in ipairs(tab.panes) do
+    if p.is_zoomed then
+      zoom = " 󰍉"
+      break
+    end
+  end
+
+  local tab_text = icon .. " " .. title .. zoom
+
+  -- Truncate if too long (account for pill glyphs)
+  local text_max = max_width - 4
+  if #tab_text > text_max then
+    tab_text = tab_text:sub(1, text_max - 1) .. "…"
+  end
+
+  if tab.is_active then
+    return {
+      { Foreground = { Color = colors.active_bg } },
+      { Background = { Color = colors.tab_bar_bg } },
+      { Text = LEFT_PILL },
+      { Foreground = { Color = colors.active_fg } },
+      { Background = { Color = colors.active_bg } },
+      { Attribute = { Intensity = "Bold" } },
+      { Text = " " .. tab_text .. " " },
+      { Foreground = { Color = colors.active_bg } },
+      { Background = { Color = colors.tab_bar_bg } },
+      { Text = RIGHT_PILL },
+    }
+  else
+    return {
+      { Foreground = { Color = icon_color } },
+      { Background = { Color = colors.tab_bar_bg } },
+      { Text = " " .. icon },
+      { Foreground = { Color = colors.inactive_fg } },
+      { Background = { Color = colors.tab_bar_bg } },
+      { Text = " " .. title .. zoom .. " " },
+    }
+  end
+end
+
+local M = {}
+
+function M.setup()
+  wezterm.on("format-tab-title", function(tab, _tabs, _panes, _config, _hover, max_width)
+    return format_tab(tab, max_width)
+  end)
+end
+
+return M

--- a/programs/wezterm/config/tab.lua
+++ b/programs/wezterm/config/tab.lua
@@ -93,12 +93,12 @@ local function format_tab(tab, max_width)
     end
   end
 
-  local tab_text = icon .. " " .. title .. zoom
+  local label = title .. zoom
 
-  -- Truncate if too long (account for pill glyphs)
-  local text_max = max_width - 4
-  if #tab_text > text_max then
-    tab_text = tab_text:sub(1, text_max - 1) .. "…"
+  -- Truncate if too long (account for pill glyphs + icon)
+  local text_max = max_width - 6
+  if #label > text_max then
+    label = label:sub(1, text_max - 1) .. "…"
   end
 
   if tab.is_active then
@@ -106,10 +106,13 @@ local function format_tab(tab, max_width)
       { Foreground = { Color = colors.active_bg } },
       { Background = { Color = colors.tab_bar_bg } },
       { Text = LEFT_PILL },
+      { Foreground = { Color = icon_color } },
+      { Background = { Color = colors.active_bg } },
+      { Text = " " .. icon },
       { Foreground = { Color = colors.active_fg } },
       { Background = { Color = colors.active_bg } },
       { Attribute = { Intensity = "Bold" } },
-      { Text = " " .. tab_text .. " " },
+      { Text = " " .. label .. " " },
       { Foreground = { Color = colors.active_bg } },
       { Background = { Color = colors.tab_bar_bg } },
       { Text = RIGHT_PILL },
@@ -121,7 +124,7 @@ local function format_tab(tab, max_width)
       { Text = " " .. icon },
       { Foreground = { Color = colors.inactive_fg } },
       { Background = { Color = colors.tab_bar_bg } },
-      { Text = " " .. title .. zoom .. " " },
+      { Text = " " .. label .. " " },
     }
   end
 end

--- a/programs/wezterm/config/tab.lua
+++ b/programs/wezterm/config/tab.lua
@@ -14,8 +14,13 @@ local LEFT_PILL = nf.ple_left_half_circle_thick
 local RIGHT_PILL = nf.ple_right_half_circle_thick
 
 -- Process definitions: icon, color, and detection function.
--- Each detect(pane) checks foreground_process_name and pane title.
+-- Each detect() checks foreground_process_name and pane title.
+-- "default" is used when no other process matches.
 local processes = {
+  default = {
+    icon = nf.dev_terminal,
+    color = "#585b70", -- surface2
+  },
   {
     icon = nf.linux_neovim,
     color = "#a6e3a1", -- green
@@ -57,7 +62,7 @@ local function get_process_info(pane)
     end
   end
 
-  return nf.dev_terminal, "#585b70" -- surface2
+  return processes.default.icon, processes.default.color
 end
 
 local function get_project_name(cwd_url)

--- a/programs/wezterm/config/tab.lua
+++ b/programs/wezterm/config/tab.lua
@@ -1,15 +1,16 @@
 local wezterm = require("wezterm")
 local nf = wezterm.nerdfonts
-
--- Nerd Font half-circle glyphs for pill shape
-local LEFT_PILL = nf.ple_left_half_circle_thick
-local RIGHT_PILL = nf.ple_right_half_circle_thick
-
--- Colors from color scheme
 local scheme = wezterm.color.get_builtin_schemes()["Catppuccin Mocha"]
-local TAB_FG = scheme.background -- base
-local TAB_BG = scheme.tab_bar.background -- mantle
-local TAB_INACTIVE_FG = scheme.tab_bar.inactive_tab.fg_color
+
+local text_color = {
+  active = scheme.background,
+  inactive = scheme.tab_bar.inactive_tab.fg_color,
+}
+
+local tab_edge = {
+  left = nf.ple_left_half_circle_thick,
+  right = nf.ple_right_half_circle_thick,
+}
 
 -- Get tab title from CWD: parse github project name or last directory component.
 local function get_title_from_cwd(pane)
@@ -96,37 +97,47 @@ end
 
 local function format_tab(tab, max_width)
   local pane = tab.active_pane
-  local icon, icon_color, title = get_process_info(pane)
-
-  local label = title
+  local icon, color, title = get_process_info(pane)
 
   -- Truncate if too long (account for pill glyphs + icon)
   local text_max = max_width - 6
-  if #label > text_max then
-    label = label:sub(1, text_max - 1) .. "…"
+  if #title > text_max then
+    title = title:sub(1, text_max - 1) .. "…"
   end
 
   if tab.is_active then
     return {
-      { Foreground = { Color = icon_color } },
-      { Background = { Color = TAB_BG } },
-      { Text = LEFT_PILL },
-      { Foreground = { Color = TAB_FG } },
-      { Background = { Color = icon_color } },
+      -- Left edge
+      { Background = { Color = "none" } },
+      { Foreground = { Color = color } },
+      { Text = tab_edge.left },
+      -- Tab title
+      { Background = { Color = color } },
+      { Foreground = { Color = text_color.active } },
       { Attribute = { Intensity = "Bold" } },
-      { Text = " " .. icon .. " " .. label .. " " },
-      { Foreground = { Color = icon_color } },
-      { Background = { Color = TAB_BG } },
-      { Text = RIGHT_PILL },
+      { Text = " " .. icon .. " " .. title .. " " },
+      -- Right edge
+      { Background = { Color = "none" } },
+      { Foreground = { Color = color } },
+      { Text = tab_edge.right },
+      -- Right padding
+      { Background = { Color = "none" } },
+      { Foreground = { Color = "none" } },
+      { Text = " " },
     }
   else
     return {
-      { Foreground = { Color = icon_color } },
-      { Background = { Color = TAB_BG } },
+      -- Tab title
+      { Background = { Color = "none" } },
+      { Foreground = { Color = color } },
       { Text = "  " .. icon },
-      { Foreground = { Color = TAB_INACTIVE_FG } },
-      { Background = { Color = TAB_BG } },
-      { Text = " " .. label .. "  " },
+      { Background = { Color = "none" } },
+      { Foreground = { Color = text_color.inactive } },
+      { Text = " " .. title .. "  " },
+      -- Right padding
+      { Background = { Color = "none" } },
+      { Foreground = { Color = "none" } },
+      { Text = " " },
     }
   end
 end

--- a/programs/wezterm/config/tab.lua
+++ b/programs/wezterm/config/tab.lua
@@ -37,12 +37,13 @@ local function get_process_info(pane)
   return nf.dev_terminal, colors.active_bg
 end
 
-local function get_project_name(cwd_uri)
-  if not cwd_uri then
+local function get_project_name(cwd_url)
+  if not cwd_url then
     return nil
   end
 
-  local cwd = cwd_uri:match("^file://[^/]*(/.*)") or cwd_uri
+  -- current_working_dir is a Url object; use file_path field
+  local cwd = cwd_url.file_path or tostring(cwd_url)
   -- Match src/github.com/<org>/<project>
   local project = cwd:match("/src/github%.com/[^/]+/([^/]+)")
   if project then

--- a/programs/wezterm/config/tab.lua
+++ b/programs/wezterm/config/tab.lua
@@ -28,12 +28,38 @@ local process_icons = {
   rust = { icon = nf.dev_rust, color = "#fab387" },
 }
 
+-- Map pane title keywords to process_icons keys (for WSL where
+-- foreground_process_name may be unavailable)
+local title_patterns = {
+  { pattern = "[Nn]vim", key = "nvim" },
+  { pattern = "[Dd]ocker", key = "docker" },
+  { pattern = "[Ss][Ss][Hh]", key = "ssh" },
+  { pattern = "[Cc]laude", key = "claude" },
+  { pattern = "[Nn]ode", key = "node" },
+  { pattern = "[Pp]ython", key = "python" },
+  { pattern = "[Rr]uby", key = "ruby" },
+}
+
 local function get_process_info(pane)
-  local process_name = pane.foreground_process_name:match("([^/\\]+)$") or ""
+  -- Try foreground_process_name first (basename)
+  local proc = pane.foreground_process_name or ""
+  local process_name = proc:match("([^/\\]+)$") or ""
   local info = process_icons[process_name]
   if info then
     return info.icon, info.color
   end
+
+  -- Fallback: match against pane title (useful on WSL)
+  local title = pane.title or ""
+  for _, entry in ipairs(title_patterns) do
+    if title:find(entry.pattern) then
+      info = process_icons[entry.key]
+      if info then
+        return info.icon, info.color
+      end
+    end
+  end
+
   return nf.dev_terminal, colors.active_bg
 end
 

--- a/programs/wezterm/default.nix
+++ b/programs/wezterm/default.nix
@@ -9,6 +9,7 @@
 
       require("config.font").apply_to_config(config)
       require("config.appearance").apply_to_config(config)
+      require("config.tab").setup()
 
       return config
     '';


### PR DESCRIPTION
## Summary

- Add `config/tab.lua` with `format-tab-title` event handler for custom tab rendering
- Pill-shaped active tabs using Nerd Font half-circle glyphs with Catppuccin Mocha blue accent
- Process-aware icons: nvim, docker, ssh, claude, node, python, ruby, go, cargo/rust each with distinct Nerd Font icon and color
- Project name extraction from CWD by parsing `src/github.com/<org>/<project>` paths with fallback to last directory component
- Zoom indicator (magnify icon) when a pane is zoomed
- Tab bar positioned at bottom with new-tab button hidden
- Tab bar background color set to Catppuccin Mocha mantle

## Test plan

- [x] Run `hms` to deploy configuration
- [ ] Open WezTerm and verify tab bar appears at bottom
- [ ] Verify active tab has pill shape with blue accent color
- [ ] Open multiple tabs and verify inactive tabs show muted styling
- [ ] Run `nvim` in a tab and verify nvim icon appears
- [ ] Verify project name displays correctly for repos under `src/github.com/`