### PR TITLE
feat(wezterm): add key bindings for panes, tabs, and workspaces

### DIFF
--- a/programs/wezterm/config/keymaps.lua
+++ b/programs/wezterm/config/keymaps.lua
@@ -18,23 +18,23 @@ function M.apply_to_config(config)
     { key = "r", mods = "LEADER", action = act.ActivateKeyTable({ name = "resize_pane", one_shot = false }) },
 
     -- Pane focus
-    { key = "h", mods = "CTRL|SHIFT", action = act.ActivatePaneDirection("Left") },
-    { key = "j", mods = "CTRL|SHIFT", action = act.ActivatePaneDirection("Down") },
-    { key = "k", mods = "CTRL|SHIFT", action = act.ActivatePaneDirection("Up") },
-    { key = "l", mods = "CTRL|SHIFT", action = act.ActivatePaneDirection("Right") },
+    { key = "h", mods = "ALT", action = act.ActivatePaneDirection("Left") },
+    { key = "j", mods = "ALT", action = act.ActivatePaneDirection("Down") },
+    { key = "k", mods = "ALT", action = act.ActivatePaneDirection("Up") },
+    { key = "l", mods = "ALT", action = act.ActivatePaneDirection("Right") },
 
     -- Tab navigation
-    { key = "h", mods = "ALT", action = act.ActivateTabRelative(-1) },
-    { key = "l", mods = "ALT", action = act.ActivateTabRelative(1) },
+    { key = "h", mods = "CTRL|SHIFT", action = act.ActivateTabRelative(-1) },
+    { key = "l", mods = "CTRL|SHIFT", action = act.ActivateTabRelative(1) },
     { key = "n", mods = "CTRL|SHIFT", action = act.SpawnTab("CurrentPaneDomain") },
 
     -- Workspace (session) navigation
-    { key = "j", mods = "ALT", action = act.SwitchWorkspaceRelative(1) },
-    { key = "k", mods = "ALT", action = act.SwitchWorkspaceRelative(-1) },
-    { key = "s", mods = "ALT", action = act.ShowLauncherArgs({ flags = "FUZZY|WORKSPACES" }) },
+    { key = "j", mods = "CTRL|SHIFT", action = act.SwitchWorkspaceRelative(1) },
+    { key = "k", mods = "CTRL|SHIFT", action = act.SwitchWorkspaceRelative(-1) },
+    { key = "s", mods = "CTRL|SHIFT", action = act.ShowLauncherArgs({ flags = "FUZZY|WORKSPACES" }) },
     {
-      key = "n",
-      mods = "LEADER",
+      key = "m",
+      mods = "CTRL|SHIFT",
       action = act.PromptInputLine({
         description = "Enter name for new workspace",
         action = wezterm.action_callback(function(window, pane, line)

--- a/programs/wezterm/config/keymaps.lua
+++ b/programs/wezterm/config/keymaps.lua
@@ -31,12 +31,11 @@ function M.apply_to_config(config)
     -- Workspace (session) navigation
     { key = "j", mods = "CTRL|SHIFT", action = act.SwitchWorkspaceRelative(1) },
     { key = "k", mods = "CTRL|SHIFT", action = act.SwitchWorkspaceRelative(-1) },
-    { key = "s", mods = "CTRL|SHIFT", action = act.ShowLauncherArgs({ flags = "FUZZY|WORKSPACES" }) },
     {
-      key = "m",
+      key = "s",
       mods = "CTRL|SHIFT",
       action = act.PromptInputLine({
-        description = "Enter name for new workspace",
+        description = "Enter workspace name (switch to existing or create new)",
         action = wezterm.action_callback(function(window, pane, line)
           if line then
             window:perform_action(act.SwitchToWorkspace({ name = line }), pane)

--- a/programs/wezterm/config/keymaps.lua
+++ b/programs/wezterm/config/keymaps.lua
@@ -1,0 +1,57 @@
+local wezterm = require("wezterm")
+local act = wezterm.action
+
+local M = {}
+
+function M.apply_to_config(config)
+  config.leader = { key = "x", mods = "CTRL", timeout_milliseconds = 2000 }
+
+  config.keys = {
+    -- Pass through Ctrl+X to shell (e.g. Ctrl+X Ctrl+E for edit-command-line)
+    { key = "x", mods = "LEADER", action = act.SendKey({ key = "x", mods = "CTRL" }) },
+
+    -- Pane splits
+    { key = "\\", mods = "LEADER", action = act.SplitPane({ direction = "Down" }) },
+    { key = "|", mods = "LEADER|SHIFT", action = act.SplitPane({ direction = "Right" }) },
+
+    -- Pane resize mode
+    { key = "r", mods = "LEADER", action = act.ActivateKeyTable({ name = "resize_pane", one_shot = false }) },
+
+    -- Pane focus
+    { key = "h", mods = "CTRL|SHIFT", action = act.ActivatePaneDirection("Left") },
+    { key = "j", mods = "CTRL|SHIFT", action = act.ActivatePaneDirection("Down") },
+    { key = "k", mods = "CTRL|SHIFT", action = act.ActivatePaneDirection("Up") },
+    { key = "l", mods = "CTRL|SHIFT", action = act.ActivatePaneDirection("Right") },
+
+    -- Tab navigation
+    { key = "h", mods = "LEADER", action = act.ActivateTabRelative(-1) },
+    { key = "l", mods = "LEADER", action = act.ActivateTabRelative(1) },
+    { key = "t", mods = "LEADER", action = act.SpawnTab("CurrentPaneDomain") },
+
+    -- Workspace (session) navigation
+    { key = "j", mods = "LEADER", action = act.SwitchWorkspaceRelative(1) },
+    { key = "k", mods = "LEADER", action = act.SwitchWorkspaceRelative(-1) },
+    { key = "s", mods = "LEADER", action = act.ShowLauncherArgs({ flags = "FUZZY|WORKSPACES" }) },
+    { key = "n", mods = "LEADER", action = act.SwitchToWorkspace() },
+
+    -- Clipboard
+    { key = "c", mods = "CTRL|SHIFT", action = act.CopyTo("Clipboard") },
+    { key = "v", mods = "CTRL|SHIFT", action = act.PasteFrom("Clipboard") },
+
+    -- Copy mode & search
+    { key = "Space", mods = "CTRL|SHIFT", action = act.ActivateCopyMode },
+    { key = "f", mods = "CTRL|SHIFT", action = act.Search("CurrentSelectionOrEmptyString") },
+  }
+
+  config.key_tables = {
+    resize_pane = {
+      { key = "h", action = act.AdjustPaneSize({ "Left", 1 }) },
+      { key = "l", action = act.AdjustPaneSize({ "Right", 1 }) },
+      { key = "k", action = act.AdjustPaneSize({ "Up", 1 }) },
+      { key = "j", action = act.AdjustPaneSize({ "Down", 1 }) },
+      { key = "Escape", action = "PopKeyTable" },
+    },
+  }
+end
+
+return M

--- a/programs/wezterm/config/keymaps.lua
+++ b/programs/wezterm/config/keymaps.lua
@@ -26,7 +26,7 @@ function M.apply_to_config(config)
     -- Tab navigation
     { key = "h", mods = "ALT", action = act.ActivateTabRelative(-1) },
     { key = "l", mods = "ALT", action = act.ActivateTabRelative(1) },
-    { key = "t", mods = "ALT", action = act.SpawnTab("CurrentPaneDomain") },
+    { key = "n", mods = "CTRL|SHIFT", action = act.SpawnTab("CurrentPaneDomain") },
 
     -- Workspace (session) navigation
     { key = "j", mods = "ALT", action = act.SwitchWorkspaceRelative(1) },

--- a/programs/wezterm/config/keymaps.lua
+++ b/programs/wezterm/config/keymaps.lua
@@ -24,8 +24,8 @@ function M.apply_to_config(config)
     { key = "l", mods = "CTRL|SHIFT", action = act.ActivatePaneDirection("Right") },
 
     -- Tab navigation
-    { key = "h", mods = "ALT", action = act.ActivateTabRelative(1) },
-    { key = "l", mods = "ALT", action = act.ActivateTabRelative(-1) },
+    { key = "h", mods = "ALT", action = act.ActivateTabRelative(-1) },
+    { key = "l", mods = "ALT", action = act.ActivateTabRelative(1) },
     { key = "t", mods = "ALT", action = act.SpawnTab("CurrentPaneDomain") },
 
     -- Workspace (session) navigation

--- a/programs/wezterm/config/keymaps.lua
+++ b/programs/wezterm/config/keymaps.lua
@@ -24,9 +24,9 @@ function M.apply_to_config(config)
     { key = "l", mods = "CTRL|SHIFT", action = act.ActivatePaneDirection("Right") },
 
     -- Tab navigation
-    { key = "h", mods = "LEADER", action = act.ActivateTabRelative(1) },
-    { key = "l", mods = "LEADER", action = act.ActivateTabRelative(-1) },
-    { key = "t", mods = "LEADER", action = act.SpawnTab("CurrentPaneDomain") },
+    { key = "h", mods = "ALT", action = act.ActivateTabRelative(1) },
+    { key = "l", mods = "ALT", action = act.ActivateTabRelative(-1) },
+    { key = "t", mods = "ALT", action = act.SpawnTab("CurrentPaneDomain") },
 
     -- Workspace (session) navigation
     { key = "j", mods = "LEADER", action = act.SwitchWorkspaceRelative(1) },

--- a/programs/wezterm/config/keymaps.lua
+++ b/programs/wezterm/config/keymaps.lua
@@ -24,8 +24,8 @@ function M.apply_to_config(config)
     { key = "l", mods = "CTRL|SHIFT", action = act.ActivatePaneDirection("Right") },
 
     -- Tab navigation
-    { key = "h", mods = "LEADER", action = act.ActivateTabRelative(-1) },
-    { key = "l", mods = "LEADER", action = act.ActivateTabRelative(1) },
+    { key = "h", mods = "LEADER", action = act.ActivateTabRelative(1) },
+    { key = "l", mods = "LEADER", action = act.ActivateTabRelative(-1) },
     { key = "t", mods = "LEADER", action = act.SpawnTab("CurrentPaneDomain") },
 
     -- Workspace (session) navigation

--- a/programs/wezterm/config/keymaps.lua
+++ b/programs/wezterm/config/keymaps.lua
@@ -32,7 +32,18 @@ function M.apply_to_config(config)
     { key = "j", mods = "LEADER", action = act.SwitchWorkspaceRelative(1) },
     { key = "k", mods = "LEADER", action = act.SwitchWorkspaceRelative(-1) },
     { key = "s", mods = "LEADER", action = act.ShowLauncherArgs({ flags = "FUZZY|WORKSPACES" }) },
-    { key = "n", mods = "LEADER", action = act.SwitchToWorkspace() },
+    {
+      key = "n",
+      mods = "LEADER",
+      action = act.PromptInputLine({
+        description = "Enter name for new workspace",
+        action = wezterm.action_callback(function(window, pane, line)
+          if line then
+            window:perform_action(act.SwitchToWorkspace({ name = line }), pane)
+          end
+        end),
+      }),
+    },
 
     -- Clipboard
     { key = "c", mods = "CTRL|SHIFT", action = act.CopyTo("Clipboard") },

--- a/programs/wezterm/config/keymaps.lua
+++ b/programs/wezterm/config/keymaps.lua
@@ -29,9 +29,9 @@ function M.apply_to_config(config)
     { key = "t", mods = "ALT", action = act.SpawnTab("CurrentPaneDomain") },
 
     -- Workspace (session) navigation
-    { key = "j", mods = "LEADER", action = act.SwitchWorkspaceRelative(1) },
-    { key = "k", mods = "LEADER", action = act.SwitchWorkspaceRelative(-1) },
-    { key = "s", mods = "LEADER", action = act.ShowLauncherArgs({ flags = "FUZZY|WORKSPACES" }) },
+    { key = "j", mods = "ALT", action = act.SwitchWorkspaceRelative(1) },
+    { key = "k", mods = "ALT", action = act.SwitchWorkspaceRelative(-1) },
+    { key = "s", mods = "ALT", action = act.ShowLauncherArgs({ flags = "FUZZY|WORKSPACES" }) },
     {
       key = "n",
       mods = "LEADER",

--- a/programs/wezterm/default.nix
+++ b/programs/wezterm/default.nix
@@ -10,6 +10,7 @@
       require("config.font").apply_to_config(config)
       require("config.appearance").apply_to_config(config)
       require("config.tab").setup()
+      require("config.keymaps").apply_to_config(config)
 
       return config
     '';


### PR DESCRIPTION
## Summary
- Add `keymaps.lua` config module with leader key (`Ctrl+X`, 2s timeout) and key bindings
- Pane splits: `Leader+\` horizontal, `Leader+|` vertical
- Pane focus: `Alt+hjkl`
- Pane resize mode: `Leader+r` then `hjkl`, `Escape` to exit
- Tab navigation: `Ctrl+Shift+h/l`, new tab `Ctrl+Shift+N`
- Workspace navigation: `Ctrl+Shift+j/k` to switch, `Ctrl+Shift+S` for fuzzy launcher with new workspace creation
- Clipboard: `Ctrl+Shift+c/v`, copy mode `Ctrl+Shift+Space`, search `Ctrl+Shift+F`
- `Leader+x` passes through `Ctrl+X` to shell for `Ctrl+X Ctrl+E`

## Test plan
- [x] `hms` deploys successfully
- [ ] `Leader+\` splits pane horizontally, `Leader+|` splits vertically
- [ ] `Alt+hjkl` moves focus between panes
- [ ] `Leader+r` enters resize mode, `hjkl` resizes, `Escape` exits
- [ ] `Ctrl+Shift+h/l` switches tabs, `Ctrl+Shift+N` creates new tab
- [ ] `Ctrl+Shift+j/k` switches workspaces
- [ ] `Ctrl+Shift+S` opens workspace launcher with fuzzy search and new workspace creation
- [ ] `Ctrl+Shift+Space` enters copy mode
- [ ] `Leader+x` sends `Ctrl+X` to shell