### PR TITLE
feat(wezterm): add workspace rename keybinding

### DIFF
--- a/programs/wezterm/config/keymaps.lua
+++ b/programs/wezterm/config/keymaps.lua
@@ -72,6 +72,23 @@ function M.apply_to_config(config)
         )
       end),
     },
+    {
+      key = "r",
+      mods = "CTRL|SHIFT",
+      action = wezterm.action_callback(function(window, pane)
+        window:perform_action(
+          act.PromptInputLine({
+            description = "Enter new name for workspace: " .. window:active_workspace(),
+            action = wezterm.action_callback(function(window, pane, line)
+              if line then
+                wezterm.mux.rename_workspace(wezterm.mux.get_active_workspace(), line)
+              end
+            end),
+          }),
+          pane
+        )
+      end),
+    },
 
     -- Clipboard
     { key = "c", mods = "CTRL|SHIFT", action = act.CopyTo("Clipboard") },


### PR DESCRIPTION
## Summary
- Add `Ctrl+Shift+r` keybinding to rename the current workspace
- Uses `PromptInputLine` to prompt for a new name, showing the current workspace name in the description
- Calls `wezterm.mux.rename_workspace()` to perform the rename

## Test plan
- [ ] Run `hms` to deploy
- [ ] Press `Ctrl+Shift+r` and verify the rename dialog appears with the current workspace name
- [ ] Enter a new name and confirm the tab bar updates
- [ ] Press `Ctrl+Shift+r` and cancel (Escape) to verify no rename occurs