### PR TITLE
feat(wezterm): add status bar with mode indicator, date, hostname, and battery

### DIFF
--- a/programs/wezterm/config/statusbar.lua
+++ b/programs/wezterm/config/statusbar.lua
@@ -1,0 +1,104 @@
+local wezterm = require("wezterm")
+local nf = wezterm.nerdfonts
+local scheme = wezterm.color.get_builtin_schemes()["Catppuccin Mocha"]
+
+-- Catppuccin Mocha palette
+local colors = {
+  lavender = scheme.brights[5],
+  red = scheme.ansi[2],
+  yellow = scheme.ansi[4],
+  peach = scheme.indexed and scheme.indexed[209] or "#fab387",
+  subtext0 = scheme.brights[1], -- surface2/subtext
+  overlay0 = "#6c7086",
+  surface0 = "#313244",
+  base = scheme.background,
+}
+
+-- Mode definitions: key_table name -> display label and color
+local modes = {
+  copy_mode = { label = " COPY ", color = colors.yellow },
+  search_mode = { label = " SEARCH ", color = colors.peach },
+  resize_pane = { label = " RESIZE ", color = colors.red },
+}
+
+local edge = {
+  left = nf.ple_left_half_circle_thick,
+  right = nf.ple_right_half_circle_thick,
+}
+
+local function left_status(window)
+  local workspace = window:active_workspace()
+  local key_table = window:active_key_table()
+  local mode = modes[key_table]
+
+  if mode then
+    return wezterm.format({
+      { Background = { Color = "none" } },
+      { Foreground = { Color = mode.color } },
+      { Text = " " .. edge.left },
+      { Background = { Color = mode.color } },
+      { Foreground = { Color = colors.base } },
+      { Attribute = { Intensity = "Bold" } },
+      { Text = mode.label },
+      { Background = { Color = "none" } },
+      { Foreground = { Color = mode.color } },
+      { Text = edge.right .. " " },
+      { Foreground = { Color = colors.lavender } },
+      { Text = workspace .. " " },
+    })
+  end
+
+  return wezterm.format({
+    { Background = { Color = "none" } },
+    { Foreground = { Color = colors.lavender } },
+    { Text = "  " .. workspace .. "  " },
+  })
+end
+
+local function right_status()
+  local cells = {}
+
+  -- Battery
+  local battery_info = wezterm.battery_info()
+  if battery_info and #battery_info > 0 then
+    local charge = battery_info[1].state_of_charge * 100
+    table.insert(cells, string.format("%.0f%%", charge))
+  end
+
+  -- Hostname
+  local hostname = wezterm.hostname()
+  hostname = hostname:gsub("%..*$", "") -- strip domain
+  table.insert(cells, hostname)
+
+  -- Date/Time
+  table.insert(cells, wezterm.strftime("%m/%d %H:%M"))
+
+  -- Build formatted output
+  local elements = {
+    { Background = { Color = "none" } },
+  }
+
+  for i, cell in ipairs(cells) do
+    if i > 1 then
+      table.insert(elements, { Foreground = { Color = colors.overlay0 } })
+      table.insert(elements, { Text = "  " .. nf.oct_dot_fill .. "  " })
+    end
+    table.insert(elements, { Foreground = { Color = colors.subtext0 } })
+    table.insert(elements, { Text = cell })
+  end
+
+  table.insert(elements, { Text = "  " })
+
+  return wezterm.format(elements)
+end
+
+local M = {}
+
+function M.setup()
+  wezterm.on("update-status", function(window)
+    window:set_left_status(left_status(window))
+    window:set_right_status(right_status())
+  end)
+end
+
+return M

--- a/programs/wezterm/config/tab.lua
+++ b/programs/wezterm/config/tab.lua
@@ -148,17 +148,6 @@ function M.setup()
   wezterm.on("format-tab-title", function(tab, _tabs, _panes, _config, _hover, max_width)
     return format_tab(tab, max_width)
   end)
-
-  local workspace_color = scheme.brights[5] -- lavender
-
-  wezterm.on("update-status", function(window)
-    local workspace = window:active_workspace()
-    window:set_left_status(wezterm.format({
-      { Background = { Color = "none" } },
-      { Foreground = { Color = workspace_color } },
-      { Text = "  " .. workspace .. "  " },
-    }))
-  end)
 end
 
 return M

--- a/programs/wezterm/default.nix
+++ b/programs/wezterm/default.nix
@@ -10,6 +10,7 @@
       require("config.font").apply_to_config(config)
       require("config.appearance").apply_to_config(config)
       require("config.tab").setup()
+      require("config.statusbar").setup()
       require("config.keymaps").apply_to_config(config)
 
       return config


### PR DESCRIPTION
## Summary
- Add `statusbar.lua` module with `update-status` event handler for both left and right status areas
- Left status: show workspace name in lavender, with pill-shaped mode indicator (COPY/SEARCH/RESIZE) in distinct Catppuccin colors when active
- Right status: display battery percentage, hostname, and date/time separated by dot separators
- Move `update-status` handler out of `tab.lua` into the new dedicated module
- Register statusbar module in `default.nix`

## Test plan
- [ ] Run `hms` to deploy
- [ ] Verify left status shows workspace name in lavender during normal mode
- [ ] Enter copy mode (`Ctrl+Shift+Space`) and verify COPY indicator appears in yellow
- [ ] Enter resize mode (`Ctrl+X r`) and verify RESIZE indicator appears in red
- [ ] Verify right status shows hostname and date/time
- [ ] Verify battery percentage appears if battery info is available, otherwise skipped