### PR TITLE
feat(wezterm): add vim-like search in copy mode

### DIFF
--- a/programs/wezterm/config/keymaps.lua
+++ b/programs/wezterm/config/keymaps.lua
@@ -102,19 +102,14 @@ function M.apply_to_config(config)
     {
       key = "Space",
       mods = "CTRL|SHIFT",
-      action = wezterm.action_callback(function(window, pane)
-        window:perform_action(act.ActivateCopyMode, pane)
-        window:perform_action(act.CopyMode("ClearSelectionMode"), pane)
-        window:perform_action(act.CopyMode("ClearPattern"), pane)
-      end),
+      action = act.ActivateCopyMode,
+      -- action = wezterm.action_callback(function(window, pane)
+      --   window:perform_action(act.ActivateCopyMode, pane)
+      --   window:perform_action(act.CopyMode("ClearSelectionMode"), pane)
+      --   window:perform_action(act.CopyMode("ClearPattern"), pane)
+      -- end),
     },
   }
-
-  -- Vim-like copy mode (defined from scratch for full control)
-  local clear_and_close = act.Multiple({
-    act.CopyMode("ClearPattern"),
-    act.CopyMode("Close"),
-  })
 
   local copy_mode = {
     -- Movement: h j k l
@@ -184,8 +179,22 @@ function M.apply_to_config(config)
     },
 
     -- Exit: q Escape Ctrl+C
-    { key = "q", mods = "NONE", action = clear_and_close },
-    { key = "c", mods = "CTRL", action = clear_and_close },
+    {
+      key = "q",
+      mods = "NONE",
+      action = act.Multiple({
+        act.CopyMode("ClearPattern"),
+        act.CopyMode("Close"),
+      }),
+    },
+    {
+      key = "c",
+      mods = "CTRL",
+      action = act.Multiple({
+        act.CopyMode("ClearPattern"),
+        act.CopyMode("Close"),
+      }),
+    },
   }
 
   local search_mode = {

--- a/programs/wezterm/config/keymaps.lua
+++ b/programs/wezterm/config/keymaps.lua
@@ -8,20 +8,24 @@ function M.apply_to_config(config)
 
   config.keys = {
     -- Pass through Ctrl+X to shell (e.g. Ctrl+X Ctrl+E for edit-command-line)
-    { key = "x", mods = "LEADER", action = act.SendKey({ key = "x", mods = "CTRL" }) },
+    { key = "x",  mods = "LEADER",       action = act.SendKey({ key = "x", mods = "CTRL" }) },
 
     -- Pane splits
-    { key = "\\", mods = "LEADER", action = act.SplitPane({ direction = "Down" }) },
-    { key = "|", mods = "LEADER|SHIFT", action = act.SplitPane({ direction = "Right" }) },
+    { key = "\\", mods = "LEADER",       action = act.SplitPane({ direction = "Down" }) },
+    { key = "|",  mods = "LEADER|SHIFT", action = act.SplitPane({ direction = "Right" }) },
 
     -- Pane resize mode
-    { key = "r", mods = "LEADER", action = act.ActivateKeyTable({ name = "resize_pane", one_shot = false }) },
+    {
+      key = "r",
+      mods = "LEADER",
+      action = act.ActivateKeyTable({ name = "resize_pane", one_shot = false }),
+    },
 
     -- Pane focus
-    { key = "h", mods = "ALT", action = act.ActivatePaneDirection("Left") },
-    { key = "j", mods = "ALT", action = act.ActivatePaneDirection("Down") },
-    { key = "k", mods = "ALT", action = act.ActivatePaneDirection("Up") },
-    { key = "l", mods = "ALT", action = act.ActivatePaneDirection("Right") },
+    { key = "h", mods = "ALT",        action = act.ActivatePaneDirection("Left") },
+    { key = "j", mods = "ALT",        action = act.ActivatePaneDirection("Down") },
+    { key = "k", mods = "ALT",        action = act.ActivatePaneDirection("Up") },
+    { key = "l", mods = "ALT",        action = act.ActivatePaneDirection("Right") },
 
     -- Tab navigation
     { key = "h", mods = "CTRL|SHIFT", action = act.ActivateTabRelative(-1) },
@@ -94,17 +98,61 @@ function M.apply_to_config(config)
     { key = "c", mods = "CTRL|SHIFT", action = act.CopyTo("Clipboard") },
     { key = "v", mods = "CTRL|SHIFT", action = act.PasteFrom("Clipboard") },
 
-    -- Copy mode & search
-    { key = "Space", mods = "CTRL|SHIFT", action = act.ActivateCopyMode },
-    { key = "f", mods = "CTRL|SHIFT", action = act.Search("CurrentSelectionOrEmptyString") },
+    -- Copy mode (use / to search within copy mode)
+    {
+      key = "Space",
+      mods = "CTRL|SHIFT",
+      action = wezterm.action_callback(function(window, pane)
+        window:perform_action(act.ActivateCopyMode, pane)
+        window:perform_action(act.CopyMode("ClearSelectionMode"), pane)
+        window:perform_action(act.CopyMode("ClearPattern"), pane)
+      end),
+    },
+  }
+
+  -- Copy mode: clear search state on every exit, add vim-like / n N
+  local copy_mode = wezterm.gui.default_key_tables().copy_mode
+  local clear_and_close = act.Multiple({
+    act.CopyMode("ClearPattern"),
+    act.CopyMode("Close"),
+  })
+  for i, binding in ipairs(copy_mode) do
+    -- Replace all exit bindings (Escape, Ctrl+C, Ctrl+G) to clear pattern first
+    if (binding.key == "Escape" and binding.mods == "NONE")
+      or (binding.key == "c" and binding.mods == "CTRL")
+      or (binding.key == "g" and binding.mods == "CTRL") then
+      copy_mode[i].action = clear_and_close
+    end
+  end
+  table.insert(copy_mode, { key = "/", mods = "NONE", action = act.Search("CurrentSelectionOrEmptyString") })
+  table.insert(copy_mode, { key = "n", mods = "NONE", action = act.CopyMode("PriorMatch") })
+  table.insert(copy_mode, { key = "N", mods = "SHIFT", action = act.CopyMode("NextMatch") })
+
+  -- Search mode: Enter accepts and returns to copy mode, Escape cancels and returns to copy mode
+  local search_mode = {
+    { key = "Enter", mods = "NONE", action = act.CopyMode("AcceptPattern") },
+    { key = "Escape", mods = "NONE", action = act.Multiple({
+      act.CopyMode("ClearPattern"),
+      act.CopyMode("AcceptPattern"),
+    }) },
+    { key = "n", mods = "CTRL", action = act.CopyMode("NextMatch") },
+    { key = "p", mods = "CTRL", action = act.CopyMode("PriorMatch") },
+    { key = "r", mods = "CTRL", action = act.CopyMode("CycleMatchType") },
+    { key = "u", mods = "CTRL", action = act.CopyMode("ClearPattern") },
+    { key = "PageUp", mods = "NONE", action = act.CopyMode("PriorMatchPage") },
+    { key = "PageDown", mods = "NONE", action = act.CopyMode("NextMatchPage") },
+    { key = "UpArrow", mods = "NONE", action = act.CopyMode("PriorMatch") },
+    { key = "DownArrow", mods = "NONE", action = act.CopyMode("NextMatch") },
   }
 
   config.key_tables = {
+    copy_mode = copy_mode,
+    search_mode = search_mode,
     resize_pane = {
-      { key = "h", action = act.AdjustPaneSize({ "Left", 1 }) },
-      { key = "l", action = act.AdjustPaneSize({ "Right", 1 }) },
-      { key = "k", action = act.AdjustPaneSize({ "Up", 1 }) },
-      { key = "j", action = act.AdjustPaneSize({ "Down", 1 }) },
+      { key = "h",      action = act.AdjustPaneSize({ "Left", 1 }) },
+      { key = "l",      action = act.AdjustPaneSize({ "Right", 1 }) },
+      { key = "k",      action = act.AdjustPaneSize({ "Up", 1 }) },
+      { key = "j",      action = act.AdjustPaneSize({ "Down", 1 }) },
       { key = "Escape", action = "PopKeyTable" },
     },
   }

--- a/programs/wezterm/config/keymaps.lua
+++ b/programs/wezterm/config/keymaps.lua
@@ -169,9 +169,17 @@ function M.apply_to_config(config)
     },
 
     -- Search: / n N
-    { key = "/", mods = "NONE",  action = act.Search({ CaseInSensitiveString = "" }) },
-    { key = "n", mods = "NONE",  action = act.CopyMode("NextMatch") },
-    { key = "N", mods = "SHIFT", action = act.CopyMode("PriorMatch") },
+    { key = "/", mods = "NONE", action = act.Search({ CaseInSensitiveString = "" }) },
+    {
+      key = "n",
+      mods = "NONE",
+      action = act.Multiple({ act.CopyMode("NextMatch"), act.CopyMode("ClearSelectionMode") }),
+    },
+    {
+      key = "N",
+      mods = "SHIFT",
+      action = act.Multiple({ act.CopyMode("PriorMatch"), act.CopyMode("ClearSelectionMode") }),
+    },
     {
       key = "Escape",
       mods = "NONE",
@@ -198,7 +206,11 @@ function M.apply_to_config(config)
   }
 
   local search_mode = {
-    { key = "Enter", mods = "NONE", action = act.CopyMode("AcceptPattern") },
+    {
+      key = "Enter",
+      mods = "NONE",
+      action = act.Multiple({ act.CopyMode("AcceptPattern"), act.CopyMode("ClearSelectionMode") }),
+    },
     {
       key = "Escape",
       mods = "NONE",

--- a/programs/wezterm/config/statusbar.lua
+++ b/programs/wezterm/config/statusbar.lua
@@ -17,7 +17,7 @@ local colors = {
 -- Mode definitions: key_table name -> display label and color
 local modes = {
   copy_mode = { label = " COPY ", color = colors.yellow },
-  search_mode = { label = " SEARCH ", color = colors.peach },
+  search_mode = { label = " COPY ", color = colors.yellow },
   resize_pane = { label = " RESIZE ", color = colors.red },
 }
 


### PR DESCRIPTION
## Summary
- Remove standalone search mode (`Ctrl+Shift+F`) in favor of vim-like `/` search within copy mode
- Add `/` in copy mode to open search dialog
- `Enter` in search accepts pattern and returns to copy mode at match
- `Escape` in search cancels (clears pattern) and returns to copy mode
- `n`/`N` in copy mode to navigate matches (prior/next)
- Clear search state (pattern + selection) on copy mode entry and exit
- Known limitation: cursor position from previous search may persist on copy mode re-entry due to WezTerm internals

Closes #174

## Test plan
- [ ] Run `hms` to deploy
- [ ] `Ctrl+Shift+Space` to enter copy mode, verify no stale search state
- [ ] `/` to search, type pattern, `Enter` to accept → returns to copy mode at match
- [ ] `n` to go to next match (upward), `N` to go to previous match (downward)
- [ ] `/` to search, `Escape` → returns to copy mode with pattern cleared
- [ ] `Escape` to exit copy mode, re-enter → verify search state is cleared