### PR TITLE
feat(wezterm): simplify status bar mode indicator

### DIFF
--- a/programs/wezterm/config/statusbar.lua
+++ b/programs/wezterm/config/statusbar.lua
@@ -16,42 +16,25 @@ local colors = {
 
 -- Mode definitions: key_table name -> display label and color
 local modes = {
-  copy_mode = { label = " COPY ", color = colors.yellow },
-  search_mode = { label = " COPY ", color = colors.yellow },
-  resize_pane = { label = " RESIZE ", color = colors.red },
+  copy_mode = { label = "COPY", color = colors.yellow },
+  search_mode = { label = "COPY", color = colors.yellow },
+  resize_pane = { label = "RESIZE", color = colors.red },
 }
-
-local edge = {
-  left = nf.ple_left_half_circle_thick,
-  right = nf.ple_right_half_circle_thick,
-}
+local default_mode = { label = "NORMAL", color = colors.lavender }
 
 local function left_status(window)
   local workspace = window:active_workspace()
   local key_table = window:active_key_table()
-  local mode = modes[key_table]
-
-  if mode then
-    return wezterm.format({
-      { Background = { Color = "none" } },
-      { Foreground = { Color = mode.color } },
-      { Text = " " .. edge.left },
-      { Background = { Color = mode.color } },
-      { Foreground = { Color = colors.base } },
-      { Attribute = { Intensity = "Bold" } },
-      { Text = mode.label },
-      { Background = { Color = "none" } },
-      { Foreground = { Color = mode.color } },
-      { Text = edge.right .. " " },
-      { Foreground = { Color = colors.lavender } },
-      { Text = workspace .. " " },
-    })
-  end
+  local mode = modes[key_table] or default_mode
 
   return wezterm.format({
     { Background = { Color = "none" } },
+    { Foreground = { Color = mode.color } },
+    { Attribute = { Intensity = "Bold" } },
+    { Text = "  " .. mode.label .. "  " },
+    { Attribute = { Intensity = "Normal" } },
     { Foreground = { Color = colors.lavender } },
-    { Text = "  " .. workspace .. "  " },
+    { Text = workspace .. "  " },
   })
 end
 

--- a/programs/wezterm/config/statusbar.lua
+++ b/programs/wezterm/config/statusbar.lua
@@ -16,8 +16,8 @@ local colors = {
 
 -- Mode definitions: key_table name -> display label and color
 local modes = {
-  copy_mode = { label = "COPY", color = colors.yellow },
-  search_mode = { label = "COPY", color = colors.yellow },
+  copy_mode = { label = " COPY ", color = colors.yellow },
+  search_mode = { label = " COPY ", color = colors.yellow },
   resize_pane = { label = "RESIZE", color = colors.red },
 }
 local default_mode = { label = "NORMAL", color = colors.lavender }


### PR DESCRIPTION
## Summary
- Replace pill-shaped mode indicator (half-circle edges + colored background) with plain bold text to prevent tab position jumping when switching modes
- Always display mode label including NORMAL for the default state
- Consistent layout: `  MODE  workspace  ` across all modes

## Test plan
- [ ] Normal mode shows `NORMAL` in lavender
- [ ] Copy mode (`Ctrl+Shift+Space`) shows `COPY` in yellow
- [ ] Resize mode (`Ctrl+X r`) shows `RESIZE` in red
- [ ] Tabs do not shift position when entering/exiting modes