### PR TITLE
feat(wezterm): add background transparency

### DIFF
--- a/programs/wezterm/config/appearance.lua
+++ b/programs/wezterm/config/appearance.lua
@@ -22,6 +22,9 @@ function M.apply_to_config(config)
     },
   }
 
+  -- Background opacity
+  config.window_background_opacity = 0.90
+
   -- Dim inactive panes to visually distinguish the active one
   config.inactive_pane_hsb = {
     saturation = 0.8,

--- a/programs/wezterm/config/appearance.lua
+++ b/programs/wezterm/config/appearance.lua
@@ -18,7 +18,7 @@ function M.apply_to_config(config)
   -- Tab bar colors (Catppuccin Mocha)
   config.colors = {
     tab_bar = {
-      background = "#181825", -- mantle
+      background = "none",
     },
   }
 


### PR DESCRIPTION
## Summary
- Set `window_background_opacity = 0.90` for subtle background transparency

## Test plan
- [ ] Background is slightly transparent