### PR TITLE
feat(wezterm): launch WSL Ubuntu by default on Windows

### DIFF
--- a/programs/wezterm/default.nix
+++ b/programs/wezterm/default.nix
@@ -13,6 +13,16 @@
       require("config.statusbar").setup()
       require("config.keymaps").apply_to_config(config)
 
+      -- Launch WSL by default when running on Windows
+      if wezterm.target_triple:find("windows") then
+        for _, domain in ipairs(wezterm.default_wsl_domains()) do
+          if domain.name:find("^WSL:Ubuntu") then
+            config.default_domain = domain.name
+            break
+          end
+        end
+      end
+
       return config
     '';
   };


### PR DESCRIPTION
## Summary
- Dynamically detect WSL Ubuntu domain and set it as default when running on Windows
- Uses `wezterm.default_wsl_domains()` to find the first `WSL:Ubuntu*` domain, supporting any Ubuntu version (22.04, 24.04, etc.)

## Test plan
- [ ] WezTerm on Windows launches directly into WSL Ubuntu shell