### PR TITLE
feat(wezterm): keep window size fixed when changing font size

### DIFF
--- a/programs/wezterm/config/font.lua
+++ b/programs/wezterm/config/font.lua
@@ -5,6 +5,7 @@ local M = {}
 function M.apply_to_config(config)
   config.font = wezterm.font("UbuntuSansMono Nerd Font Mono")
   config.font_size = 13.0
+  config.adjust_window_size_when_changing_font_size = false
 
   -- Light hinting for smoother glyph shapes
   config.freetype_load_target = "Light"


### PR DESCRIPTION
## Summary
- Set `adjust_window_size_when_changing_font_size = false` to prevent window resizing when zooming in/out

## Test plan
- [ ] Ctrl+= / Ctrl+- changes font size without resizing the window