### PR TITLE
feat(wezterm): change status bar date format to ISO 8601 with seconds

### DIFF
--- a/programs/wezterm/config/statusbar.lua
+++ b/programs/wezterm/config/statusbar.lua
@@ -54,7 +54,7 @@ local function right_status()
   table.insert(cells, hostname)
 
   -- Date/Time
-  table.insert(cells, wezterm.strftime("%m/%d %H:%M"))
+  table.insert(cells, wezterm.strftime("%Y-%m-%d %H:%M:%S"))
 
   -- Build formatted output
   local elements = {


### PR DESCRIPTION
## Summary
- Change date/time format from `%m/%d %H:%M` to `%Y-%m-%d %H:%M:%S`

## Test plan
- [ ] Status bar shows date in `2026-02-11 12:34:56` format