### PR TITLE
feat(wezterm): use brighter colors for status bar text and active tab

### DIFF
--- a/programs/wezterm/config/statusbar.lua
+++ b/programs/wezterm/config/statusbar.lua
@@ -8,8 +8,8 @@ local colors = {
   red = scheme.ansi[2],
   yellow = scheme.ansi[4],
   peach = scheme.indexed and scheme.indexed[209] or "#fab387",
-  subtext0 = scheme.brights[1], -- surface2/subtext
-  overlay0 = "#6c7086",
+  subtext0 = scheme.ansi[8], -- subtext1
+  overlay0 = scheme.brights[8], -- subtext0
   surface0 = "#313244",
   base = scheme.background,
 }

--- a/programs/wezterm/config/tab.lua
+++ b/programs/wezterm/config/tab.lua
@@ -33,7 +33,7 @@ end
 local processes = {
   default = {
     icon = nf.dev_terminal,
-    color = scheme.brights[1], -- surface2
+    color = scheme.brights[8], -- subtext0
     get_title = function(pane)
       return get_title_from_cwd(pane) or "~"
     end,


### PR DESCRIPTION
## Summary
- Use `scheme.ansi[8]` / `scheme.brights[8]` for right status bar text and separator instead of hardcoded hex values
- Use `scheme.brights[8]` for default active tab background color for better visibility

## Test plan
- [ ] Right status bar text is clearly readable
- [ ] Active tab background is visually distinct