### PR TITLE
fix(wezterm): use PowerShell with UTF-8 for Windows username detection

### DIFF
--- a/programs/wezterm/default.nix
+++ b/programs/wezterm/default.nix
@@ -32,7 +32,7 @@
 
   home.activation.deployWeztermToWindows = lib.mkIf isWSL (
     lib.hm.dag.entryAfter [ "linkGeneration" ] ''
-      win_user=$(/mnt/c/Windows/System32/cmd.exe /c "echo %USERNAME%" 2>/dev/null | tr -d '\r')
+      win_user=$(/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -NoProfile -Command '[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; $env:USERNAME' 2>/dev/null | tr -d '\r')
       if [ -n "$win_user" ]; then
         win_config="/mnt/c/Users/$win_user/.config/wezterm"
         rm -rf "$win_config"


### PR DESCRIPTION
## Summary
- Switch from cmd.exe to PowerShell for detecting Windows username in WSL
- Set explicit UTF-8 output encoding to handle Japanese usernames correctly
- Fixes `mkdir: cannot create directory` error caused by garbled non-ASCII usernames

## Test plan
- [ ] Run `hms` on WSL with a Japanese Windows username
- [ ] Verify WezTerm config is deployed to the correct Windows user directory