### PR TITLE
feat(nix): add nodejs for Mason package installation

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -22,6 +22,7 @@
       # Languages & runtimes
       go
       lua
+      nodejs
       python3
       ruby
       deno


### PR DESCRIPTION
## Summary
- Add Node.js to home.nix packages
- Required by Mason to install npm-based language servers (e.g., copilot-language-server)

## Test plan
- [ ] Run `hms` to apply configuration
- [ ] Open nvim and verify copilot-language-server installs without error