### PR TITLE
feat(claude): enable Agent Teams feature

### DIFF
--- a/programs/claude/settings.json
+++ b/programs/claude/settings.json
@@ -36,7 +36,9 @@
     ]
   },
   "model": "opus",
-  "agentTeams": true,
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  },
   "hooks": {
     "Notification": [
       {

--- a/programs/claude/settings.json
+++ b/programs/claude/settings.json
@@ -36,6 +36,7 @@
     ]
   },
   "model": "opus",
+  "agentTeams": true,
   "hooks": {
     "Notification": [
       {


### PR DESCRIPTION
## Summary
- Enable Agent Teams feature by setting `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` environment variable in Claude Code settings
- Agent Teams is an experimental feature that allows multiple Claude Code instances to work together as a team

## Test plan
- [ ] Run `hms` to apply the configuration
- [ ] Verify Agent Teams is enabled in Claude Code