### PR TITLE
fix(nix): remove docker package

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -51,9 +51,6 @@
       # Cloud
       awscli2
       google-cloud-sdk
-
-      # Containers
-      docker
     ];
   };
 


### PR DESCRIPTION
## Summary
- Remove `docker` package from home.nix
- Docker daemon requires system-level installation (apt) for proper systemd integration on WSL2

## Test plan
- [ ] Run `hms` to apply the configuration