### PR TITLE
docs: add Docker installation instructions for WSL2

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,4 @@ Install [UbuntuSans Nerd Font](https://www.nerdfonts.com/font-downloads) (`Ubunt
 
 ### Docker (WSL2)
 
-Install Docker Engine via apt for systemd integration. See [official documentation](https://docs.docker.com/engine/install/ubuntu/).
-
-```shell
-sudo apt install docker.io
-sudo systemctl enable --now docker
-sudo usermod -aG docker $USER
-```
-
-Restart WSL to apply the group change.
+See [Install Docker Engine on Ubuntu](https://docs.docker.com/engine/install/ubuntu/).

--- a/README.md
+++ b/README.md
@@ -49,3 +49,15 @@ Install [UbuntuSans Nerd Font](https://www.nerdfonts.com/font-downloads) (`Ubunt
 ### WSL
 
 - Remove the `Ctrl+V` keybinding in Windows Terminal. Use `Ctrl+Shift+V` to paste instead.
+
+### Docker (WSL2)
+
+Install Docker Engine via apt for systemd integration. See [official documentation](https://docs.docker.com/engine/install/ubuntu/).
+
+```shell
+sudo apt install docker.io
+sudo systemctl enable --now docker
+sudo usermod -aG docker $USER
+```
+
+Restart WSL to apply the group change.


### PR DESCRIPTION
## Summary
- Add Docker installation instructions to Manual Setup section
- Include link to official Docker documentation
- Provide quick setup commands using apt and systemd

## Test plan
- [ ] Verify README renders correctly on GitHub