### PR TITLE
feat(claude): add PreToolUse hook for Bash command validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dot_git/
 result
+node_modules/

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,21 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "devDependencies": {
+        "@types/bun": "^1.3.9",
+        "@types/node": "^25.2.3",
+      },
+    },
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
+
+    "@types/node": ["@types/node@25.2.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ=="],
+
+    "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
+
+    "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {},
+  "devDependencies": {
+    "@types/bun": "^1.3.9",
+    "@types/node": "^25.2.3"
+  }
+}

--- a/programs/claude/default.nix
+++ b/programs/claude/default.nix
@@ -4,6 +4,10 @@
   home.file = {
     ".claude/settings.json".source = ./settings.json;
 
+    ".claude/scripts/pre-bash.ts" = {
+      source = ./scripts/pre-bash.ts;
+    };
+
     ".claude/scripts/statusline-command.sh" = {
       source = ./scripts/statusline-command.sh;
       executable = true;

--- a/programs/claude/scripts/pre-bash.ts
+++ b/programs/claude/scripts/pre-bash.ts
@@ -9,14 +9,27 @@
 // --- Types ---
 
 interface HookInput {
+  /** Current session identifier */
   session_id: string;
+  /** Path to conversation JSON */
+  transcript_path: string;
+  /** Current working directory when the hook is invoked */
+  cwd: string;
+  /** Current permission mode: "default", "plan", "acceptEdits", "dontAsk", or "bypassPermissions" */
+  permission_mode: string;
+  /** Name of the event that fired */
+  hook_event_name: string;
+  /** Name of the tool being called */
   tool_name: string;
+  /** The parameters sent to the tool */
   tool_input: {
     command: string;
     description?: string;
     timeout?: number;
     run_in_background?: boolean;
   };
+  /** Unique identifier for this tool call */
+  tool_use_id: string;
 }
 
 interface DenyResult {
@@ -26,10 +39,16 @@ interface DenyResult {
 
 interface HookOutput {
   hookSpecificOutput: {
+    /** Name of the event that fired */
     hookEventName: "PreToolUse";
-    permissionDecision: "deny";
-    permissionDecisionReason: string;
-    additionalContext: string;
+    /** "allow" bypasses the permission system, "deny" prevents the tool call, "ask" prompts the user to confirm */
+    permissionDecision: "allow" | "deny" | "ask";
+    /** For "allow" and "ask", shown to the user but not Claude. For "deny", shown to Claude */
+    permissionDecisionReason?: string;
+    /** Modifies the tool's input parameters before execution. Combine with "allow" to auto-approve, or "ask" to show the modified input to the user */
+    updatedInput?: Record<string, unknown>;
+    /** String added to Claude's context before the tool executes */
+    additionalContext?: string;
   };
 }
 

--- a/programs/claude/scripts/pre-bash.ts
+++ b/programs/claude/scripts/pre-bash.ts
@@ -8,27 +8,42 @@
 
 // --- Types ---
 
-interface HookInput {
-  /** Current session identifier */
+/**
+ * Common input fields.
+ * @see https://code.claude.com/docs/en/hooks#common-input-fields
+ */
+interface HookCommonInput {
+  /** Current session identifier. */
   session_id: string;
-  /** Path to conversation JSON */
+  /** Path to conversation JSON. */
   transcript_path: string;
-  /** Current working directory when the hook is invoked */
+  /** Current working directory when the hook is invoked. */
   cwd: string;
-  /** Current permission mode: "default", "plan", "acceptEdits", "dontAsk", or "bypassPermissions" */
+  /** Current permission mode: "default", "plan", "acceptEdits", "dontAsk", or "bypassPermissions". */
   permission_mode: string;
-  /** Name of the event that fired */
+  /** Name of the event that fired. */
   hook_event_name: string;
-  /** Name of the tool being called */
+}
+
+/**
+ * Tool-specific input fields for PreToolUse.
+ * @see https://code.claude.com/docs/en/hooks#pretooluse-input
+ */
+interface HookInput extends HookCommonInput {
+  /** Name of the tool being called. */
   tool_name: string;
-  /** The parameters sent to the tool */
+  /** The parameters sent to the tool. */
   tool_input: {
+    /** The command to execute. */
     command: string;
+    /** Clear, concise description of what this command does. */
     description?: string;
+    /** Optional timeout in milliseconds (max 600000). */
     timeout?: number;
+    /** Set to true to run this command in the background. */
     run_in_background?: boolean;
   };
-  /** Unique identifier for this tool call */
+  /** Unique identifier for this tool call. */
   tool_use_id: string;
 }
 
@@ -37,17 +52,21 @@ interface DenyResult {
   suggestion: string;
 }
 
+/**
+ * Hook output for PreToolUse.
+ * @see https://code.claude.com/docs/en/hooks#hook-output
+ */
 interface HookOutput {
   hookSpecificOutput: {
-    /** Name of the event that fired */
+    /** Name of the event that fired. */
     hookEventName: "PreToolUse";
-    /** "allow" bypasses the permission system, "deny" prevents the tool call, "ask" prompts the user to confirm */
+    /** "allow" bypasses the permission system, "deny" prevents the tool call, "ask" prompts the user to confirm. */
     permissionDecision: "allow" | "deny" | "ask";
-    /** For "allow" and "ask", shown to the user but not Claude. For "deny", shown to Claude */
+    /** For "allow" and "ask", shown to the user but not Claude. For "deny", shown to Claude. */
     permissionDecisionReason?: string;
-    /** Modifies the tool's input parameters before execution. Combine with "allow" to auto-approve, or "ask" to show the modified input to the user */
+    /** Modifies the tool's input parameters before execution. Combine with "allow" to auto-approve, or "ask" to show the modified input to the user. */
     updatedInput?: Record<string, unknown>;
-    /** String added to Claude's context before the tool executes */
+    /** String added to Claude's context before the tool executes. */
     additionalContext?: string;
   };
 }

--- a/programs/claude/scripts/pre-bash.ts
+++ b/programs/claude/scripts/pre-bash.ts
@@ -1,0 +1,95 @@
+#!/usr/bin/env bun
+
+/**
+ * PreToolUse hook for Bash commands.
+ * Runs multiple checkers against the command and returns a deny decision
+ * if any checker rejects it.
+ */
+
+// --- Types ---
+
+interface HookInput {
+  session_id: string;
+  tool_name: string;
+  tool_input: {
+    command: string;
+    description?: string;
+    timeout?: number;
+    run_in_background?: boolean;
+  };
+}
+
+interface DenyResult {
+  reason: string;
+  suggestion: string;
+}
+
+interface HookOutput {
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse";
+    permissionDecision: "deny";
+    permissionDecisionReason: string;
+    additionalContext: string;
+  };
+}
+
+// --- Feature: Forbidden Command Patterns ---
+
+interface ForbiddenPattern {
+  pattern: RegExp;
+  reason: string;
+  suggestion: string;
+}
+
+const forbiddenPatterns: ForbiddenPattern[] = [
+  {
+    pattern: /\bgit\s+-C\b/,
+    reason: "`git -C` is forbidden.",
+    suggestion:
+      "Run git commands from the target directory directly instead of using `git -C`.",
+  },
+];
+
+function checkForbiddenPatterns(command: string): DenyResult | null {
+  for (const { pattern, reason, suggestion } of forbiddenPatterns) {
+    if (pattern.test(command)) {
+      return { reason, suggestion };
+    }
+  }
+  return null;
+}
+
+// --- Checker Pipeline ---
+
+type Checker = (command: string) => DenyResult | null;
+
+const checkers: Checker[] = [checkForbiddenPatterns];
+
+// --- Main ---
+
+async function main() {
+  const text = await Bun.stdin.text();
+  const input: HookInput = JSON.parse(text);
+  const command = input.tool_input.command;
+
+  for (const checker of checkers) {
+    const result = checker(command);
+    if (result) {
+      const output: HookOutput = {
+        hookSpecificOutput: {
+          hookEventName: "PreToolUse",
+          permissionDecision: "deny",
+          permissionDecisionReason: `${result.reason} ${result.suggestion}`,
+          additionalContext: result.suggestion,
+        },
+      };
+      console.log(JSON.stringify(output));
+      process.exit(0);
+    }
+  }
+
+  // All checks passed — no opinion, let normal permission flow continue.
+  process.exit(0);
+}
+
+main();

--- a/programs/claude/settings.json
+++ b/programs/claude/settings.json
@@ -40,6 +40,18 @@
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
   },
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun ~/.claude/scripts/pre-bash.ts",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
     "Notification": [
       {
         "matcher": "idle_prompt",


### PR DESCRIPTION
## Summary
- Add a PreToolUse hook that runs `pre-bash.ts` via bun before every Bash tool call
- The script has an extensible checker pipeline for adding multiple validation features
- First feature: forbidden command pattern matching that blocks commands and suggests alternatives
- First pattern: block `git -C` usage and suggest running git from the target directory directly

## Test plan
- [x] Run `hms` to apply the configuration
- [x] Verify that `git -C` commands are blocked by the hook with a deny message
- [x] Verify that other Bash commands are not affected