### PR TITLE
feat(claude): add nownabe-marketplace plugin marketplace

### DIFF
--- a/programs/claude/settings.json
+++ b/programs/claude/settings.json
@@ -77,12 +77,21 @@
       }
     ]
   },
+  "extraKnownMarketplaces": {
+    "nownabe-marketplace": {
+      "source": {
+        "source": "github",
+        "repo": "nownabe/claude-marketplace"
+      }
+    }
+  },
   "enabledPlugins": {
     "frontend-design@claude-plugins-official": true,
     "context7@claude-plugins-official": true,
     "code-review@claude-plugins-official": true,
     "example-skills@anthropic-agent-skills": true,
-    "playwright@claude-plugins-official": true
+    "playwright@claude-plugins-official": true,
+    "hello-world@nownabe-marketplace": true
   },
   "attribution": {
     "commit": "",


### PR DESCRIPTION
## Summary
- Add `nownabe/claude-marketplace` as an extra known marketplace via `extraKnownMarketplaces`
- Enable `hello-world@nownabe-marketplace` plugin

## Test plan
- [ ] Run `hms` to apply the configuration
- [ ] Verify the marketplace appears in `/plugin` Marketplaces tab
- [ ] Verify `hello-world` plugin is loaded