### PR TITLE
refactor(claude): externalize forbidden patterns to JSON config files

### DIFF
--- a/programs/claude/README.md
+++ b/programs/claude/README.md
@@ -1,0 +1,50 @@
+# Claude Code Configuration
+
+## pre-bash.json
+
+Configuration file for the `pre-bash.ts` PreToolUse hook, which validates Bash commands before execution.
+
+The hook loads `.claude/pre-bash.json` from CWD up to HOME, merging all found files. Child-level (closer to CWD) entries take priority over parent-level (closer to HOME) entries.
+
+Default config is deployed to `~/.claude/pre-bash.json` via Home Manager. Projects can add their own `.claude/pre-bash.json` to extend or override the defaults.
+
+### Schema
+
+```json
+{
+  "forbiddenPatterns": [
+    {
+      "pattern": "<regex>",
+      "reason": "<message shown to Claude>",
+      "suggestion": "<guidance for alternative approach>"
+    }
+  ]
+}
+```
+
+### Fields
+
+#### `forbiddenPatterns`
+
+A list of regex patterns to deny. Each entry has:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `pattern` | `string` | Yes | Regex pattern to match against the command |
+| `reason` | `string` | Yes (unless disabled) | Why the command is forbidden |
+| `suggestion` | `string` | Yes (unless disabled) | Alternative approach for Claude |
+| `disabled` | `boolean` | No | Set to `true` to disable this pattern |
+
+### Overriding parent patterns
+
+To disable a pattern defined in a parent-level config, re-declare it with `disabled: true` in a child-level config:
+
+```json
+{
+  "forbiddenPatterns": [
+    { "pattern": "\\bgit\\s+-C\\b", "disabled": true }
+  ]
+}
+```
+
+When the same `pattern` string appears in multiple files, the child-level entry wins.

--- a/programs/claude/default.nix
+++ b/programs/claude/default.nix
@@ -4,7 +4,7 @@
   home.file = {
     ".claude/settings.json".source = ./settings.json;
 
-    ".claude/forbidden-patterns.json".source = ./forbidden-patterns.json;
+    ".claude/pre-bash.json".source = ./pre-bash.json;
 
     ".claude/scripts/pre-bash.ts" = {
       source = ./scripts/pre-bash.ts;

--- a/programs/claude/default.nix
+++ b/programs/claude/default.nix
@@ -4,6 +4,8 @@
   home.file = {
     ".claude/settings.json".source = ./settings.json;
 
+    ".claude/forbidden-patterns.json".source = ./forbidden-patterns.json;
+
     ".claude/scripts/pre-bash.ts" = {
       source = ./scripts/pre-bash.ts;
     };

--- a/programs/claude/forbidden-patterns.json
+++ b/programs/claude/forbidden-patterns.json
@@ -1,7 +1,0 @@
-[
-  {
-    "pattern": "\\bgit\\s+-C\\b",
-    "reason": "`git -C` is forbidden.",
-    "suggestion": "Run git commands from the target directory directly instead of using `git -C`."
-  }
-]

--- a/programs/claude/forbidden-patterns.json
+++ b/programs/claude/forbidden-patterns.json
@@ -1,0 +1,7 @@
+[
+  {
+    "pattern": "\\bgit\\s+-C\\b",
+    "reason": "`git -C` is forbidden.",
+    "suggestion": "Run git commands from the target directory directly instead of using `git -C`."
+  }
+]

--- a/programs/claude/pre-bash.json
+++ b/programs/claude/pre-bash.json
@@ -1,0 +1,9 @@
+{
+  "forbiddenPatterns": [
+    {
+      "pattern": "\\bgit\\s+-C\\b",
+      "reason": "`git -C` is forbidden.",
+      "suggestion": "Run git commands from the target directory directly instead of using `git -C`."
+    }
+  ]
+}

--- a/programs/claude/scripts/pre-bash.test.ts
+++ b/programs/claude/scripts/pre-bash.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { join } from "path";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import {
+  collectAncestorDirs,
+  loadForbiddenPatterns,
+  checkForbiddenPatterns,
+  type ActivePattern,
+} from "./pre-bash";
+
+describe("collectAncestorDirs", () => {
+  test("returns single directory when start equals stop", () => {
+    expect(collectAncestorDirs("/home/user", "/home/user")).toEqual([
+      "/home/user",
+    ]);
+  });
+
+  test("returns path from start to stop", () => {
+    expect(
+      collectAncestorDirs("/home/user/projects/app", "/home/user"),
+    ).toEqual([
+      "/home/user/projects/app",
+      "/home/user/projects",
+      "/home/user",
+    ]);
+  });
+
+  test("stops at filesystem root if stop is not an ancestor", () => {
+    const result = collectAncestorDirs("/tmp/a", "/other");
+    expect(result[0]).toBe("/tmp/a");
+    expect(result[result.length - 1]).toBe("/");
+  });
+});
+
+describe("checkForbiddenPatterns", () => {
+  const patterns: ActivePattern[] = [
+    {
+      pattern: "\\bgit\\s+-C\\b",
+      reason: "git -C is forbidden",
+      suggestion: "Use cd instead",
+    },
+    {
+      pattern: "\\brm\\s+-rf\\s+/\\b",
+      reason: "rm -rf / is forbidden",
+      suggestion: "Be more specific",
+    },
+  ];
+
+  test("returns null when no patterns match", () => {
+    expect(checkForbiddenPatterns("git status", patterns)).toBeNull();
+  });
+
+  test("returns deny result for matching pattern", () => {
+    const result = checkForbiddenPatterns("git -C /tmp status", patterns);
+    expect(result).toEqual({
+      reason: "git -C is forbidden",
+      suggestion: "Use cd instead",
+    });
+  });
+
+  test("returns first matching pattern", () => {
+    const result = checkForbiddenPatterns("git -C /tmp && rm -rf /", patterns);
+    expect(result?.reason).toBe("git -C is forbidden");
+  });
+
+  test("returns null for empty patterns", () => {
+    expect(checkForbiddenPatterns("git -C /tmp", [])).toBeNull();
+  });
+});
+
+describe("loadForbiddenPatterns", () => {
+  let tmpDir: string;
+  let originalHome: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "pre-bash-test-"));
+    originalHome = process.env.HOME;
+    process.env.HOME = tmpDir;
+  });
+
+  afterEach(() => {
+    process.env.HOME = originalHome;
+    rmSync(tmpDir, { recursive: true });
+  });
+
+  function writeConfig(dir: string, config: object) {
+    const claudeDir = join(dir, ".claude");
+    mkdirSync(claudeDir, { recursive: true });
+    writeFileSync(join(claudeDir, "pre-bash.json"), JSON.stringify(config));
+  }
+
+  test("returns empty array when no config files exist", () => {
+    const cwd = join(tmpDir, "a", "b");
+    mkdirSync(cwd, { recursive: true });
+    expect(loadForbiddenPatterns(cwd)).toEqual([]);
+  });
+
+  test("loads patterns from HOME", () => {
+    writeConfig(tmpDir, {
+      forbiddenPatterns: [
+        { pattern: "\\bfoo\\b", reason: "no foo", suggestion: "use bar" },
+      ],
+    });
+    expect(loadForbiddenPatterns(tmpDir)).toEqual([
+      { pattern: "\\bfoo\\b", reason: "no foo", suggestion: "use bar" },
+    ]);
+  });
+
+  test("merges patterns from multiple levels", () => {
+    const projectDir = join(tmpDir, "project");
+    mkdirSync(projectDir, { recursive: true });
+
+    writeConfig(tmpDir, {
+      forbiddenPatterns: [
+        { pattern: "\\bfoo\\b", reason: "no foo", suggestion: "use bar" },
+      ],
+    });
+    writeConfig(projectDir, {
+      forbiddenPatterns: [
+        { pattern: "\\bbaz\\b", reason: "no baz", suggestion: "use qux" },
+      ],
+    });
+
+    const result = loadForbiddenPatterns(projectDir);
+    expect(result).toHaveLength(2);
+    expect(result[0].pattern).toBe("\\bbaz\\b");
+    expect(result[1].pattern).toBe("\\bfoo\\b");
+  });
+
+  test("child overrides parent with disabled:true", () => {
+    const projectDir = join(tmpDir, "project");
+    mkdirSync(projectDir, { recursive: true });
+
+    writeConfig(tmpDir, {
+      forbiddenPatterns: [
+        { pattern: "\\bfoo\\b", reason: "no foo", suggestion: "use bar" },
+        { pattern: "\\bbaz\\b", reason: "no baz", suggestion: "use qux" },
+      ],
+    });
+    writeConfig(projectDir, {
+      forbiddenPatterns: [{ pattern: "\\bfoo\\b", disabled: true }],
+    });
+
+    const result = loadForbiddenPatterns(projectDir);
+    expect(result).toHaveLength(1);
+    expect(result[0].pattern).toBe("\\bbaz\\b");
+  });
+
+  test("child overrides parent with different reason/suggestion", () => {
+    const projectDir = join(tmpDir, "project");
+    mkdirSync(projectDir, { recursive: true });
+
+    writeConfig(tmpDir, {
+      forbiddenPatterns: [
+        { pattern: "\\bfoo\\b", reason: "original", suggestion: "original" },
+      ],
+    });
+    writeConfig(projectDir, {
+      forbiddenPatterns: [
+        { pattern: "\\bfoo\\b", reason: "overridden", suggestion: "overridden" },
+      ],
+    });
+
+    const result = loadForbiddenPatterns(projectDir);
+    expect(result).toEqual([
+      { pattern: "\\bfoo\\b", reason: "overridden", suggestion: "overridden" },
+    ]);
+  });
+
+  test("skips malformed JSON files", () => {
+    const claudeDir = join(tmpDir, ".claude");
+    mkdirSync(claudeDir, { recursive: true });
+    writeFileSync(join(claudeDir, "pre-bash.json"), "not json");
+
+    expect(loadForbiddenPatterns(tmpDir)).toEqual([]);
+  });
+
+  test("handles config without forbiddenPatterns field", () => {
+    writeConfig(tmpDir, {});
+    expect(loadForbiddenPatterns(tmpDir)).toEqual([]);
+  });
+
+  test("returns empty array when HOME is not set", () => {
+    delete process.env.HOME;
+    expect(loadForbiddenPatterns("/some/path")).toEqual([]);
+  });
+});

--- a/programs/claude/scripts/pre-bash.ts
+++ b/programs/claude/scripts/pre-bash.ts
@@ -73,7 +73,7 @@ interface HookOutput {
 
 // --- Feature: Forbidden Command Patterns ---
 
-type ForbiddenPatternEntry =
+export type ForbiddenPatternEntry =
   | { pattern: string; reason: string; suggestion: string; disabled?: false }
   | { pattern: string; disabled: true };
 
@@ -87,7 +87,7 @@ interface PreBashConfig {
  * Collect directories from `startDir` up to (and including) `stopDir`.
  * Returns paths from startDir (most specific) to stopDir (least specific).
  */
-function collectAncestorDirs(startDir: string, stopDir: string): string[] {
+export function collectAncestorDirs(startDir: string, stopDir: string): string[] {
   const { resolve, dirname } = require("path") as typeof import("path");
   const start = resolve(startDir);
   const stop = resolve(stopDir);
@@ -110,7 +110,7 @@ function collectAncestorDirs(startDir: string, stopDir: string): string[] {
  * occurrence (child) wins, allowing child-level files to override
  * parent patterns (e.g. disable them).
  */
-function loadForbiddenPatterns(cwd: string): ActivePattern[] {
+export function loadForbiddenPatterns(cwd: string): ActivePattern[] {
   const { join } = require("path") as typeof import("path");
   const { existsSync, readFileSync } =
     require("fs") as typeof import("fs");
@@ -144,9 +144,9 @@ function loadForbiddenPatterns(cwd: string): ActivePattern[] {
   );
 }
 
-type ActivePattern = Extract<ForbiddenPatternEntry, { reason: string }>;
+export type ActivePattern = Extract<ForbiddenPatternEntry, { reason: string }>;
 
-function checkForbiddenPatterns(
+export function checkForbiddenPatterns(
   command: string,
   patterns: ActivePattern[],
 ): DenyResult | null {
@@ -194,4 +194,6 @@ async function main() {
   process.exit(0);
 }
 
-main();
+if (import.meta.main) {
+  main();
+}


### PR DESCRIPTION
## Summary
- Extract hardcoded forbidden patterns from `pre-bash.ts` into a separate `forbidden-patterns.json` file
- Deploy `~/.claude/forbidden-patterns.json` as the default patterns via Home Manager
- The hook script walks from CWD up to HOME, loading `.claude/forbidden-patterns.json` at each directory level, merging all found patterns
- Projects can define their own `.claude/forbidden-patterns.json` to add project-specific rules

## Test plan
- [ ] Run `hms` to deploy the new JSON file
- [ ] Verify `~/.claude/forbidden-patterns.json` exists with the default pattern
- [ ] Test that forbidden commands are still denied by the hook
- [ ] Test adding a project-level `.claude/forbidden-patterns.json` and verify it is applied