### PR TITLE
fix(claude): update marketplace repo name to nownabe/claude

### DIFF
--- a/programs/claude/settings.json
+++ b/programs/claude/settings.json
@@ -81,7 +81,7 @@
     "nownabe-marketplace": {
       "source": {
         "source": "github",
-        "repo": "nownabe/claude-marketplace"
+        "repo": "nownabe/claude"
       }
     }
   },


### PR DESCRIPTION
## Summary
- Update `extraKnownMarketplaces` repo from `nownabe/claude-marketplace` to `nownabe/claude`

## Test plan
- [ ] Run `hms` to deploy the updated settings
- [ ] Verify marketplace plugins resolve correctly