### PR TITLE
feat(claude): add global CLAUDE.md with PR assignee instruction

### DIFF
--- a/programs/claude/CLAUDE.md
+++ b/programs/claude/CLAUDE.md
@@ -1,0 +1,5 @@
+# Global Instructions
+
+## GitHub
+
+- When creating a pull request, always assign `nownabe` as the assignee

--- a/programs/claude/default.nix
+++ b/programs/claude/default.nix
@@ -2,6 +2,8 @@
 
 {
   home.file = {
+    ".claude/CLAUDE.md".source = ./CLAUDE.md;
+
     ".claude/settings.json".source = ./settings.json;
 
     ".claude/pre-bash.json".source = ./pre-bash.json;


### PR DESCRIPTION
## Summary
- Add `~/.claude/CLAUDE.md` managed by Home Manager with global instructions for Claude Code
- Include GitHub section instructing to assign `nownabe` as PR assignee
- Register the file in `programs/claude/default.nix` for deployment via `hms`

## Test plan
- [ ] Run `hms` and verify `~/.claude/CLAUDE.md` is created
- [ ] Confirm Claude Code picks up the global instruction