### PR TITLE
fix(zsh): add ~/.bun/bin to PATH

### DIFF
--- a/programs/zsh/config/path.zsh
+++ b/programs/zsh/config/path.zsh
@@ -1,1 +1,1 @@
-export PATH="$HOME/.local/bin:$PATH"
+export PATH="$HOME/.bun/bin:$HOME/.local/bin:$PATH"


### PR DESCRIPTION
## Summary
- Add `~/.bun/bin` to PATH in `programs/zsh/config/path.zsh`
- Enables globally installed bun packages (`bun install -g`) to be found in the shell

## Test plan
- [ ] Run `hms` to apply the configuration
- [ ] Open a new shell and verify `echo $PATH` includes `~/.bun/bin`
- [ ] Verify globally installed bun packages are accessible