### PR TITLE
feat(nvim): enable OS clipboard integration

### DIFF
--- a/programs/claude/CLAUDE.md
+++ b/programs/claude/CLAUDE.md
@@ -1,0 +1,5 @@
+# Global Instructions
+
+## GitHub
+
+- When creating a pull request, always assign `nownabe` as the assignee

--- a/programs/claude/default.nix
+++ b/programs/claude/default.nix
@@ -2,6 +2,8 @@
 
 {
   home.file = {
+    ".claude/CLAUDE.md".source = ./CLAUDE.md;
+
     ".claude/settings.json".source = ./settings.json;
 
     ".claude/pre-bash.json".source = ./pre-bash.json;

--- a/programs/nvim/config/lua/plugins/astrocore.lua
+++ b/programs/nvim/config/lua/plugins/astrocore.lua
@@ -4,6 +4,7 @@ return {
   opts = {
     options = {
       opt = {
+        clipboard = "unnamedplus",
         relativenumber = false,
         spell = true,
         wrap = true,


### PR DESCRIPTION
## Summary
- Set `clipboard = "unnamedplus"` in Neovim's astrocore options to use the OS clipboard for all yank/paste operations

## Test plan
- [ ] Run `hms` to apply the configuration
- [ ] Open Neovim, yank text with `y`, and verify it's available in the OS clipboard
- [ ] Copy text in another application and verify it can be pasted in Neovim with `p`