### PR TITLE
feat(nvim): enable OS clipboard integration

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -37,7 +37,6 @@
       deadnix
 
       # CLI tools
-      xsel
       ripgrep
       fzf
       yq-go

--- a/home.nix
+++ b/home.nix
@@ -37,6 +37,7 @@
       deadnix
 
       # CLI tools
+      xsel
       ripgrep
       fzf
       yq-go

--- a/programs/nvim/config/init.lua
+++ b/programs/nvim/config/init.lua
@@ -6,12 +6,12 @@ if vim.fn.has("wsl") == 1 then
   vim.g.clipboard = {
     name = "WslClipboard",
     copy = {
-      ["+"] = "clip.exe",
-      ["*"] = "clip.exe",
+      ["+"] = "/mnt/c/Windows/System32/clip.exe",
+      ["*"] = "/mnt/c/Windows/System32/clip.exe",
     },
     paste = {
-      ["+"] = 'powershell.exe -NoLogo -NoProfile -c [Console]::Out.Write($(Get-Clipboard -Raw).tostring().replace("`r", ""))',
-      ["*"] = 'powershell.exe -NoLogo -NoProfile -c [Console]::Out.Write($(Get-Clipboard -Raw).tostring().replace("`r", ""))',
+      ["+"] = '/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -NoLogo -NoProfile -c [Console]::Out.Write($(Get-Clipboard -Raw).tostring().replace("`r", ""))',
+      ["*"] = '/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -NoLogo -NoProfile -c [Console]::Out.Write($(Get-Clipboard -Raw).tostring().replace("`r", ""))',
     },
     cache_enabled = 0,
   }

--- a/programs/nvim/config/init.lua
+++ b/programs/nvim/config/init.lua
@@ -2,6 +2,21 @@
 
 vim.opt.clipboard = "unnamedplus"
 
+if vim.fn.has("wsl") == 1 then
+  vim.g.clipboard = {
+    name = "WslClipboard",
+    copy = {
+      ["+"] = "clip.exe",
+      ["*"] = "clip.exe",
+    },
+    paste = {
+      ["+"] = 'powershell.exe -NoLogo -NoProfile -c [Console]::Out.Write($(Get-Clipboard -Raw).tostring().replace("`r", ""))',
+      ["*"] = 'powershell.exe -NoLogo -NoProfile -c [Console]::Out.Write($(Get-Clipboard -Raw).tostring().replace("`r", ""))',
+    },
+    cache_enabled = 0,
+  }
+end
+
 -- Bootstrap lazy.nvim
 local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
 if not vim.uv.fs_stat(lazypath) then

--- a/programs/nvim/config/init.lua
+++ b/programs/nvim/config/init.lua
@@ -1,5 +1,7 @@
 -- https://lazy.folke.io/installation
 
+vim.opt.clipboard = "unnamedplus"
+
 -- Bootstrap lazy.nvim
 local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
 if not vim.uv.fs_stat(lazypath) then

--- a/programs/nvim/config/init.lua
+++ b/programs/nvim/config/init.lua
@@ -10,8 +10,8 @@ if vim.fn.has("wsl") == 1 then
       ["*"] = "/mnt/c/Windows/System32/clip.exe",
     },
     paste = {
-      ["+"] = '/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -NoLogo -NoProfile -c [Console]::Out.Write($(Get-Clipboard -Raw).tostring().replace("`r", ""))',
-      ["*"] = '/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -NoLogo -NoProfile -c [Console]::Out.Write($(Get-Clipboard -Raw).tostring().replace("`r", ""))',
+      ["+"] = "xsel --clipboard --output",
+      ["*"] = "xsel --output",
     },
     cache_enabled = 0,
   }

--- a/programs/nvim/config/lua/plugins/astrocore.lua
+++ b/programs/nvim/config/lua/plugins/astrocore.lua
@@ -4,7 +4,6 @@ return {
   opts = {
     options = {
       opt = {
-        clipboard = "unnamedplus",
         relativenumber = false,
         spell = true,
         wrap = true,

--- a/programs/nvim/config/lua/plugins/astrocore.lua
+++ b/programs/nvim/config/lua/plugins/astrocore.lua
@@ -4,6 +4,7 @@ return {
   opts = {
     options = {
       opt = {
+        clipboard = "unnamedplus",
         relativenumber = false,
         spell = true,
         wrap = true,


### PR DESCRIPTION
## Summary
- Set `clipboard = "unnamedplus"` in Neovim's astrocore options to use the OS clipboard for all yank/paste operations

## Test plan
- [ ] Run `hms` to apply the configuration
- [ ] Open Neovim, yank text with `y`, and verify it's available in the OS clipboard
- [ ] Copy text in another application and verify it can be pasted in Neovim with `p`