### PR TITLE
fix(nix): suppress options.json store path warning

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -54,6 +54,8 @@
     ];
   };
 
+  manual.manpages.enable = false;
+
   programs = {
     home-manager.enable = true;
 


### PR DESCRIPTION
## Summary
- Disable `manual.manpages.enable` to suppress the `builtins.derivation` warning about `options.json` referencing a store path without proper context
- This is a known Home Manager issue ([home-manager#7935](https://github.com/nix-community/home-manager/issues/7935)) where manpage generation creates an `options.json` derivation with an improper store path reference
- Trade-off: `man home-configuration.nix` will no longer be available

## Test plan
- [x] Run `hms` and confirm the warning no longer appears