### PR TITLE
feat(nix): add mise for runtime version management

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -81,6 +81,11 @@
         addKeysToAgent = "yes";
       };
     };
+
+    mise = {
+      enable = true;
+      enableZshIntegration = true;
+    };
   };
 
   services.ssh-agent.enable = true;


### PR DESCRIPTION
## Summary
- Add mise via Home Manager's `programs.mise` option
- Enable zsh integration for automatic activation

## Test plan
- [ ] Run `hms` to apply configuration
- [ ] Verify `mise --version` works
- [ ] Verify mise activates in new shell sessions