### PR TITLE
feat(claude): allow @nownabe/claude-tools and document its commands

### DIFF
--- a/programs/claude/CLAUDE.md
+++ b/programs/claude/CLAUDE.md
@@ -3,3 +3,17 @@
 ## GitHub
 
 - When creating a pull request, always assign `nownabe` as the assignee
+
+## @nownabe/claude-tools
+
+`@nownabe/claude-tools` provides GitHub-related CLI utilities. Run via `bunx @nownabe/claude-tools <command>`.
+
+Available commands:
+
+- `gh add-sub-issues <parent> <sub>...` — add sub-issues to a parent issue
+- `gh get-actions-run <run_id>` — get GitHub Actions workflow run info
+- `gh get-release [--tag <tag>] [--jq <expr>]` — get release info (latest by default)
+- `gh list-sub-issues <issue_number>` — list sub-issues of an issue
+- `gh resolve-tag-sha <owner/repo> <tag>` — resolve a tag to its commit SHA (useful for pinning GitHub Actions)
+
+All commands accept `--repo <owner/repo>` to target a specific repository (defaults to current repo).

--- a/programs/claude/settings.json
+++ b/programs/claude/settings.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "permissions": {
     "allow": [
+      "Bash(bunx @nownabe/claude-tools:*)",
       "Bash(grep:*)",
       "Bash(find:*)",
       "Bash(go test:*)",


### PR DESCRIPTION
## Summary
- Add `Bash(bunx @nownabe/claude-tools:*)` to allowed permissions in global settings
- Document available `@nownabe/claude-tools` commands in global CLAUDE.md so Claude Code can leverage them effectively

## Test plan
- [ ] Verify `hms` applies successfully
- [ ] Verify `bunx @nownabe/claude-tools gh get-release` runs without permission prompt