### PR TITLE
fix(wezterm): reduce config reload race during Windows deployment

### DIFF
--- a/programs/wezterm/default.nix
+++ b/programs/wezterm/default.nix
@@ -36,7 +36,7 @@
       win_user=$(/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -NoProfile -Command '[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; $env:USERNAME' 2>/dev/null | tr -d '\r')
       if [ -n "$win_user" ]; then
         win_config="/mnt/c/Users/$win_user/.config/wezterm"
-        win_config_tmp="${win_config}.tmp.$$"
+        win_config_tmp="''${win_config}.tmp.$$"
         rm -rf "$win_config_tmp"
         mkdir -p "$win_config_tmp"
         cp -rTL "${config.home.homeDirectory}/.config/wezterm" "$win_config_tmp"

--- a/programs/wezterm/default.nix
+++ b/programs/wezterm/default.nix
@@ -36,10 +36,13 @@
       win_user=$(/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -NoProfile -Command '[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; $env:USERNAME' 2>/dev/null | tr -d '\r')
       if [ -n "$win_user" ]; then
         win_config="/mnt/c/Users/$win_user/.config/wezterm"
+        win_config_tmp="${win_config}.tmp.$$"
+        rm -rf "$win_config_tmp"
+        mkdir -p "$win_config_tmp"
+        cp -rTL "${config.home.homeDirectory}/.config/wezterm" "$win_config_tmp"
+        chmod -R u+w "$win_config_tmp"
         rm -rf "$win_config"
-        mkdir -p "$win_config"
-        cp -rTL "${config.home.homeDirectory}/.config/wezterm" "$win_config"
-        chmod -R u+w "$win_config"
+        mv "$win_config_tmp" "$win_config"
         echo "Deployed WezTerm config to $win_config"
       else
         echo "Warning: Could not detect Windows username, skipping WezTerm Windows deployment" >&2


### PR DESCRIPTION
## Summary
- WezTerm intermittently fails with `module 'config.font' not found` during `hms` runs
- Root cause: the activation script does `rm -rf` → `mkdir` → `cp`, and WezTerm's file watcher triggers a reload after `wezterm.lua` is copied but before `config/` subdirectory files are in place
- Fix: copy to a temp directory first, then `mv` to swap, minimizing the window where config is incomplete

## Test plan
- [ ] Run `hms` on WSL and confirm WezTerm config is deployed correctly
- [ ] Verify WezTerm does not show `module not found` errors after deployment