### PR TITLE
feat(claude): add knowledge-work-plugins marketplace and plugins

### DIFF
--- a/programs/claude/settings.json
+++ b/programs/claude/settings.json
@@ -54,6 +54,12 @@
         "source": "github",
         "repo": "nownabe/claude"
       }
+    },
+    "knowledge-work-plugins": {
+      "source": {
+        "source": "github",
+        "repo": "anthropics/knowledge-work-plugins"
+      }
     }
   },
   "enabledPlugins": {
@@ -63,7 +69,18 @@
     "example-skills@anthropic-agent-skills": true,
     "playwright@claude-plugins-official": true,
     "hello-world@nownabe-marketplace": true,
-    "base@nownabe-marketplace": true
+    "base@nownabe-marketplace": true,
+    "productivity@knowledge-work-plugins": true,
+    "sales@knowledge-work-plugins": true,
+    "customer-support@knowledge-work-plugins": true,
+    "product-management@knowledge-work-plugins": true,
+    "marketing@knowledge-work-plugins": true,
+    "legal@knowledge-work-plugins": true,
+    "finance@knowledge-work-plugins": true,
+    "data@knowledge-work-plugins": true,
+    "enterprise-search@knowledge-work-plugins": true,
+    "bio-research@knowledge-work-plugins": true,
+    "cowork-plugin-management@knowledge-work-plugins": true
   },
   "attribution": {
     "commit": "",


### PR DESCRIPTION
## Summary
- Add `anthropics/knowledge-work-plugins` marketplace to Claude Code settings
- Enable all 11 plugins: productivity, sales, customer-support, product-management, marketing, legal, finance, data, enterprise-search, bio-research, cowork-plugin-management

## Test plan
- [x] `hms` applies successfully
- [x] `claude plugin list` shows all plugins as enabled