### PR TITLE
feat(tmux): add tmux configuration with WezTerm-like keybindings

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -7,6 +7,7 @@
     ./programs/nvim
     ./programs/claude
     ./programs/wezterm
+    ./programs/tmux
   ];
 
   home = {

--- a/programs/tmux/README.md
+++ b/programs/tmux/README.md
@@ -27,6 +27,7 @@ Prefix: `Ctrl+X`.
 | `r` | Rename session |
 | `Space` | Enter copy mode |
 | `v` | Paste buffer |
+| `d` | Detach from session |
 | `x` | Send `Ctrl+X` to shell |
 
 ### Resize Mode (`Prefix+R`)
@@ -47,3 +48,12 @@ Prefix: `Ctrl+X`.
 | `q` / `Escape` | Cancel |
 
 Vi navigation keys (`h/j/k/l`, `w/b/e`, `0/^/$`, `g/G`, `Ctrl+u/d/b/f`, `f/F/t/T`, `/`, `n/N`) work in copy mode via `keyMode = "vi"`.
+
+## Common Commands
+
+| Command | Description |
+|---|---|
+| `tmux` | Start new session |
+| `tmux attach` | Attach to last session |
+| `tmux attach -t <name>` | Attach to named session |
+| `tmux source-file ~/.config/tmux/tmux.conf` | Reload config (also works from `prefix+:`) |

--- a/programs/tmux/README.md
+++ b/programs/tmux/README.md
@@ -1,0 +1,48 @@
+# tmux
+
+WezTerm-like keybindings for tmux. Prefix: `Ctrl+X`.
+
+## Keybindings
+
+### Alt (prefix-free)
+
+| Key | Action |
+|---|---|
+| `Alt+h` | Previous window |
+| `Alt+l` | Next window |
+| `Alt+j` | Next session |
+| `Alt+k` | Previous session |
+
+### Prefix (`Ctrl+X`) +
+
+| Key | Action |
+|---|---|
+| `h/j/k/l` | Pane navigation (left/down/up/right) |
+| `\` | Split pane below |
+| `\|` | Split pane right |
+| `R` | Enter resize mode |
+| `n` | New window |
+| `s` | Session selector (tree view) |
+| `r` | Rename session |
+| `Space` | Enter copy mode |
+| `v` | Paste buffer |
+| `x` | Send `Ctrl+X` to shell |
+
+### Resize Mode (`Prefix+R`)
+
+| Key | Action |
+|---|---|
+| `h/j/k/l` | Resize pane (repeatable) |
+| `Escape` | Exit resize mode |
+
+### Copy Mode (`Prefix+Space`)
+
+| Key | Action |
+|---|---|
+| `v` | Begin selection |
+| `V` | Select line |
+| `Ctrl+v` | Toggle rectangle selection |
+| `y` | Yank and exit (OSC 52 clipboard) |
+| `q` / `Escape` | Cancel |
+
+Vi navigation keys (`h/j/k/l`, `w/b/e`, `0/^/$`, `g/G`, `Ctrl+u/d/b/f`, `f/F/t/T`, `/`, `n/N`) work in copy mode via `keyMode = "vi"`.

--- a/programs/tmux/README.md
+++ b/programs/tmux/README.md
@@ -1,6 +1,6 @@
 # tmux
 
-WezTerm-like keybindings for tmux. Prefix: `Ctrl+X`.
+Prefix: `Ctrl+X`.
 
 ## Keybindings
 

--- a/programs/tmux/README.md
+++ b/programs/tmux/README.md
@@ -23,6 +23,7 @@ Prefix: `Ctrl+X`.
 | `R` | Enter resize mode |
 | `n` | New window |
 | `s` | Session selector (tree view) |
+| `S` | New session (prompts for name) |
 | `r` | Rename session |
 | `Space` | Enter copy mode |
 | `v` | Paste buffer |

--- a/programs/tmux/default.nix
+++ b/programs/tmux/default.nix
@@ -1,0 +1,92 @@
+{ pkgs, ... }:
+
+{
+  programs.tmux = {
+    enable = true;
+    prefix = "C-x";
+    terminal = "tmux-256color";
+    keyMode = "vi";
+    mouse = true;
+    escapeTime = 0;
+    baseIndex = 1;
+    historyLimit = 50000;
+    clock24 = true;
+    sensibleOnTop = true;
+    focusEvents = true;
+
+    plugins = [
+      {
+        plugin = pkgs.tmuxPlugins.catppuccin;
+        extraConfig = ''
+          set -g @catppuccin_flavor "mocha"
+          set -g @catppuccin_window_status_style "rounded"
+          set -g @catppuccin_session_color "#{?client_prefix,#{@thm_peach},#{@thm_lavender}}"
+        '';
+      }
+    ];
+
+    extraConfig = ''
+      # Terminal features
+      set -as terminal-features ",xterm-256color:RGB"
+      set -g set-clipboard on
+      set -g renumber-windows on
+      setw -g automatic-rename on
+
+      # Status bar
+      set -g status-left "#{E:@catppuccin_status_session}"
+      set -g status-right "#{E:@catppuccin_status_host}#{E:@catppuccin_status_date_time}"
+
+      # Inactive pane visual distinction
+      set -g window-style "fg=colour247,bg=default"
+      set -g window-active-style "fg=colour250,bg=default"
+
+      # Pane splitting
+      bind '\' split-window -v -c "#{pane_current_path}"
+      bind '|' split-window -h -c "#{pane_current_path}"
+
+      # Pane navigation
+      bind h select-pane -L
+      bind j select-pane -D
+      bind k select-pane -U
+      bind l select-pane -R
+
+      # Resize mode
+      bind R switch-client -T resize_pane
+      bind -T resize_pane h resize-pane -L 1 \; switch-client -T resize_pane
+      bind -T resize_pane j resize-pane -D 1 \; switch-client -T resize_pane
+      bind -T resize_pane k resize-pane -U 1 \; switch-client -T resize_pane
+      bind -T resize_pane l resize-pane -R 1 \; switch-client -T resize_pane
+      bind -T resize_pane Escape switch-client -T prefix
+
+      # Window navigation (prefix-free)
+      bind -n M-h previous-window
+      bind -n M-l next-window
+
+      # New window
+      bind n new-window -c "#{pane_current_path}"
+
+      # Session navigation (prefix-free)
+      bind -n M-j switch-client -n
+      bind -n M-k switch-client -p
+
+      # Session management
+      bind s choose-tree -sZ
+      bind r command-prompt -I "#S" "rename-session -- '%%'"
+
+      # Copy mode
+      bind Space copy-mode
+      bind v paste-buffer
+
+      # Copy mode vi bindings
+      bind -T copy-mode-vi y send-keys -X copy-pipe-and-cancel
+      bind -T copy-mode-vi v send-keys -X begin-selection
+      bind -T copy-mode-vi V send-keys -X select-line
+      bind -T copy-mode-vi C-v send-keys -X rectangle-toggle
+      bind -T copy-mode-vi q send-keys -X cancel
+      bind -T copy-mode-vi Escape send-keys -X cancel
+
+      # Passthrough Ctrl+X to shell
+      bind x send-keys C-x
+    '';
+  };
+}

--- a/programs/tmux/default.nix
+++ b/programs/tmux/default.nix
@@ -33,6 +33,7 @@
       setw -g automatic-rename on
 
       # Status bar
+      set -g status-left-length 100
       set -g status-left "#{E:@catppuccin_status_session}"
       set -g status-right "#{E:@catppuccin_status_host}#{E:@catppuccin_status_date_time}"
 

--- a/programs/tmux/default.nix
+++ b/programs/tmux/default.nix
@@ -71,6 +71,7 @@
 
       # Session management
       bind s choose-tree -sZ
+      bind S command-prompt "new-session -s '%%'"
       bind r command-prompt -I "#S" "rename-session -- '%%'"
 
       # Copy mode


### PR DESCRIPTION
## Summary
- Add tmux configuration module (`programs/tmux/default.nix`) managed by Nix Home Manager
- Use `Ctrl+X` prefix to match WezTerm leader key
- Catppuccin Mocha theme with rounded window status style and prefix-aware session color indicator
- Vi-mode copy with OSC 52 clipboard integration
- Prefix-free navigation: `Alt+h/l` for windows, `Alt+j/k` for sessions
- Prefix-based pane management: `h/j/k/l` navigation, `\/|` splitting, `R` for persistent resize mode
- Session management: `s` for tree selector, `r` for rename, `n` for new window
- Inactive pane dimming to approximate WezTerm's `inactive_pane_hsb`

## Test plan
- [ ] Run `hms` to apply configuration
- [ ] Launch `tmux` and verify Catppuccin Mocha theme appearance
- [ ] Verify status bar shows session name (left), hostname + date/time (right)
- [ ] Test prefix key `Ctrl+X` activates prefix (session indicator changes to peach)
- [ ] Test pane splitting: `prefix+\` (vertical), `prefix+|` (horizontal)
- [ ] Test pane navigation: `prefix+h/j/k/l`
- [ ] Test resize mode: `prefix+R` then `h/j/k/l`, `Escape` to exit
- [ ] Test window navigation: `Alt+h/l` (no prefix needed)
- [ ] Test `prefix+n` for new window
- [ ] Test session navigation: `Alt+j/k` (no prefix needed)
- [ ] Test `prefix+s` for session tree, `prefix+r` for rename
- [ ] Test copy mode: `prefix+Space`, select with `v`, yank with `y`, paste with `prefix+v`
- [ ] Test `prefix+x` sends Ctrl+X to shell