### PR TITLE
fix(tmux): improve copy mode cursor visibility

### DIFF
--- a/programs/tmux/default.nix
+++ b/programs/tmux/default.nix
@@ -37,6 +37,10 @@
       set -g status-left "#{E:@catppuccin_status_session}"
       set -g status-right "#{E:@catppuccin_status_host}#{E:@catppuccin_status_date_time}"
 
+      # Copy mode cursor style
+      set -g mode-style "reverse"
+      set -g cursor-style block
+
       # Inactive pane visual distinction
       set -g window-style "fg=colour247,bg=default"
       set -g window-active-style "fg=colour250,bg=default"


### PR DESCRIPTION
## Summary
- Set `cursor-style block` to use block cursor instead of bar in copy mode
- Set `mode-style reverse` for better visual feedback at cursor position

## Test plan
- [ ] Run `hms` and reload tmux config
- [ ] Enter copy mode (`prefix+Space`) and verify cursor is a block
- [ ] Verify selection highlight is visible with reverse style