### PR TITLE
chore(zsh): remove chezmoi alias

### DIFF
--- a/programs/zsh/default.nix
+++ b/programs/zsh/default.nix
@@ -76,7 +76,6 @@ in
       k = "kubectl";
       bat = "batcat";
       vi = "nvim";
-      c = "chezmoi";
       g = "git";
 
       # Ruby


### PR DESCRIPTION
## Summary
- Remove the `c = "chezmoi"` shell alias from zsh configuration as chezmoi is no longer used

## Test plan
- [ ] Run `hms` to apply the configuration
- [ ] Verify the `c` alias is no longer defined