### PR TITLE
feat(zsh): shorten directory path in tmux window tabs

### DIFF
--- a/programs/zsh/config/title.zsh
+++ b/programs/zsh/config/title.zsh
@@ -1,0 +1,28 @@
+# Terminal title: show shortened path (e.g., /h/n/s/g/n/dotfiles)
+# Each intermediate directory is abbreviated to its first character,
+# while the last component is shown in full.
+_short_path() {
+  local dir="${PWD/#$HOME/~}"
+  local parts=("${(@s:/:)dir}")
+  local result=""
+  local last=${#parts}
+
+  for i in {1..$last}; do
+    if [[ $i -eq $last ]]; then
+      result+="${parts[$i]}"
+    elif [[ -n "${parts[$i]}" ]]; then
+      result+="${parts[$i][1]}/"
+    else
+      result+="/"
+    fi
+  done
+
+  echo "$result"
+}
+
+_set_terminal_title() {
+  print -Pn "\e]2;$(_short_path)\a"
+}
+
+autoload -Uz add-zsh-hook
+add-zsh-hook precmd _set_terminal_title

--- a/programs/zsh/default.nix
+++ b/programs/zsh/default.nix
@@ -18,6 +18,7 @@ in
       purePromptPath = pkgs.pure-prompt;
     };
     "zsh/keybindings.zsh".source = ./config/keybindings.zsh;
+    "zsh/title.zsh".source = ./config/title.zsh;
   };
 
   programs.zsh = {


### PR DESCRIPTION
## Summary
- Add `precmd` hook to set terminal title with shortened directory path
- Intermediate directories are abbreviated to their first character (e.g., `/home/nownabe/src/github.com/nownabe/dotfiles` → `~/s/g/n/dotfiles`)
- Last directory component is kept in full for readability

## Test plan
- [ ] Open tmux and navigate to various directories
- [ ] Verify window tab shows shortened path (e.g., `~/s/g/n/dotfiles`)
- [ ] Verify home directory shows as `~`
- [ ] Verify root directory shows as `/`