### PR TITLE
feat(nix): add aqua CLI version manager

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -13,9 +13,13 @@
     let
       username = "nownabe";
       system = "x86_64-linux";
+      overlay = final: prev: {
+        aqua = final.callPackage ./packages/aqua.nix { };
+      };
       pkgs = import nixpkgs {
         inherit system;
         config.allowUnfree = true;
+        overlays = [ overlay ];
       };
       dotfilesDir = "/home/${username}/src/github.com/nownabe/dotfiles";
     in

--- a/home.nix
+++ b/home.nix
@@ -31,6 +31,7 @@
 
       # Package managers
       uv
+      aqua
 
       # Nix tools
       nil

--- a/packages/aqua.nix
+++ b/packages/aqua.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "aqua";
+  version = "2.56.7";
+
+  src = fetchurl {
+    url = "https://github.com/aquaproj/aqua/releases/download/v${version}/aqua_linux_amd64.tar.gz";
+    hash = "sha256-KMZjNSZUUawNNKNk5Xg25tc+9Vy7lpgmXOPuK5fxx8A=";
+  };
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 aqua $out/bin/aqua
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Declarative CLI Version Manager written in Go";
+    homepage = "https://aquaproj.github.io/";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+    mainProgram = "aqua";
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/programs/zsh/config/aqua.zsh
+++ b/programs/zsh/config/aqua.zsh
@@ -1,0 +1,1 @@
+export PATH="${AQUA_ROOT_DIR:-$HOME/.local/share/aquaproj-aqua}/bin:$PATH"

--- a/programs/zsh/default.nix
+++ b/programs/zsh/default.nix
@@ -13,6 +13,7 @@ in
     "zsh/utils.zsh".source = ./config/utils.zsh;
     "zsh/wsl.zsh".source = ./config/wsl.zsh;
     "zsh/mise.zsh".source = ./config/mise.zsh;
+    "zsh/aqua.zsh".source = ./config/aqua.zsh;
     "zsh/path.zsh".source = ./config/path.zsh;
     "zsh/prompt.zsh".source = pkgs.replaceVars ./config/prompt.zsh {
       purePromptPath = pkgs.pure-prompt;


### PR DESCRIPTION
## Summary
- Add aqua package using prebuilt binary from GitHub releases (v2.56.7)
- Add overlay in flake.nix to make aqua available as pkgs.aqua
- Configure PATH for aqua-installed tools in zsh

## Test plan
- [x] Run `hms` to apply configuration
- [x] Verify `aqua --version` works