### PR TITLE
chore(git): add .worktrees to global gitignore

### DIFF
--- a/programs/git/default.nix
+++ b/programs/git/default.nix
@@ -11,6 +11,7 @@ in
     ignores = [
       ".nownabe/"
       ".shogo/"
+      ".worktrees/"
       "**/.claude/settings.local.json"
     ];
 


### PR DESCRIPTION
## Summary
- Add `.worktrees/` to `programs.git.ignores` so that git worktree directories are globally ignored

## Test plan
- [ ] Run `hms` and verify `~/.config/git/ignore` contains `.worktrees/`