### PR TITLE
feat(claude): add chikuwa hooks for session lifecycle events

### DIFF
--- a/programs/claude/settings.json
+++ b/programs/claude/settings.json
@@ -105,5 +105,12 @@
   "statusLine": {
     "type": "command",
     "command": "~/.claude/scripts/statusline-command.sh"
+  },
+  "hooks": {
+    "UserPromptSubmit": [{"hooks": [{"type": "command", "command": "chikuwa hook running"}]}],
+    "Stop": [{"hooks": [{"type": "command", "command": "chikuwa hook waiting"}]}],
+    "Notification": [{"matcher": "*", "hooks": [{"type": "command", "command": "chikuwa hook notification"}]}],
+    "SessionStart": [{"hooks": [{"type": "command", "command": "chikuwa hook started"}]}],
+    "SessionEnd": [{"hooks": [{"type": "command", "command": "chikuwa hook ended"}]}]
   }
 }


### PR DESCRIPTION
## Summary
- Add Claude Code hooks to integrate with chikuwa for session lifecycle tracking
- Hooks cover: `UserPromptSubmit` (running), `Stop` (waiting), `Notification`, `SessionStart` (started), `SessionEnd` (ended)

## Test plan
- [x] Verify `hms` applies successfully
- [ ] Confirm hooks fire correctly during a Claude Code session