### PR TITLE
fix(claude): simplify chikuwa hook commands

### DIFF
--- a/programs/claude/settings.json
+++ b/programs/claude/settings.json
@@ -107,10 +107,56 @@
     "command": "~/.claude/scripts/statusline-command.sh"
   },
   "hooks": {
-    "UserPromptSubmit": [{"hooks": [{"type": "command", "command": "chikuwa hook running"}]}],
-    "Stop": [{"hooks": [{"type": "command", "command": "chikuwa hook waiting"}]}],
-    "Notification": [{"matcher": "*", "hooks": [{"type": "command", "command": "chikuwa hook notification"}]}],
-    "SessionStart": [{"hooks": [{"type": "command", "command": "chikuwa hook started"}]}],
-    "SessionEnd": [{"hooks": [{"type": "command", "command": "chikuwa hook ended"}]}]
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "chikuwa hook"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "chikuwa hook"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "chikuwa hook"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "chikuwa hook"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "chikuwa hook"
+          }
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- Unify all chikuwa hook commands to `chikuwa hook` (remove per-event arguments like `running`, `waiting`, etc.)
- Reformat hooks JSON for readability

## Test plan
- [ ] Confirm hooks fire correctly during a Claude Code session