### PR TITLE
fix(claude): add missing chikuwa hooks and fix Notification config

### DIFF
--- a/programs/claude/settings.json
+++ b/programs/claude/settings.json
@@ -107,56 +107,12 @@
     "command": "~/.claude/scripts/statusline-command.sh"
   },
   "hooks": {
-    "UserPromptSubmit": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "chikuwa hook"
-          }
-        ]
-      }
-    ],
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "chikuwa hook"
-          }
-        ]
-      }
-    ],
-    "Notification": [
-      {
-        "matcher": "*",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "chikuwa hook"
-          }
-        ]
-      }
-    ],
-    "SessionStart": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "chikuwa hook"
-          }
-        ]
-      }
-    ],
-    "SessionEnd": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "chikuwa hook"
-          }
-        ]
-      }
-    ]
+    "UserPromptSubmit": [{"hooks": [{"type": "command", "command": "chikuwa hook"}]}],
+    "PreToolUse": [{"hooks": [{"type": "command", "command": "chikuwa hook"}]}],
+    "Stop": [{"hooks": [{"type": "command", "command": "chikuwa hook"}]}],
+    "PermissionRequest": [{"hooks": [{"type": "command", "command": "chikuwa hook"}]}],
+    "Notification": [{"hooks": [{"type": "command", "command": "chikuwa hook"}]}],
+    "SessionStart": [{"hooks": [{"type": "command", "command": "chikuwa hook"}]}],
+    "SessionEnd": [{"hooks": [{"type": "command", "command": "chikuwa hook"}]}]
   }
 }


### PR DESCRIPTION
## Summary
- Add missing `PreToolUse` and `PermissionRequest` hooks
- Remove unnecessary `"matcher": "*"` from `Notification` hook to match chikuwa docs
- Compact JSON formatting for hooks

## Test plan
- [ ] Confirm all hooks fire correctly during a Claude Code session