### PR TITLE
feat(tmux): switch to another session on last window close

### DIFF
--- a/programs/tmux/default.nix
+++ b/programs/tmux/default.nix
@@ -26,6 +26,9 @@
     ];
 
     extraConfig = ''
+      # Switch to another session instead of detaching when session is destroyed
+      set -g detach-on-destroy off
+
       # Terminal features
       set -as terminal-features ",xterm-256color:RGB"
       set -g set-clipboard on


### PR DESCRIPTION
## Summary
- Add `detach-on-destroy off` to tmux config so that closing the last window in a session switches to another existing session instead of detaching from tmux

## Test plan
- [ ] Run `hms` to apply
- [ ] Open multiple tmux sessions, close all windows in one session, and verify it switches to another session