### PR TITLE
feat(nix): add chikuwa package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,7 @@
       system = "x86_64-linux";
       overlay = final: prev: {
         aqua = final.callPackage ./packages/aqua.nix { };
+        chikuwa = final.callPackage ./packages/chikuwa.nix { };
       };
       pkgs = import nixpkgs {
         inherit system;

--- a/home.nix
+++ b/home.nix
@@ -38,6 +38,9 @@
       statix
       deadnix
 
+      # AI tools
+      chikuwa
+
       # CLI tools
       ripgrep
       fzf

--- a/packages/chikuwa.nix
+++ b/packages/chikuwa.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "chikuwa";
+  version = "0.1.4";
+
+  src = fetchurl {
+    url = "https://github.com/nownabe/chikuwa/releases/download/v${version}/chikuwa-x86_64-unknown-linux-gnu.tar.gz";
+    hash = "sha256-omY+Y3HXAOUfNvQ4fcKMNohewXb4ye1N1Erddo3ufiM=";
+  };
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 chikuwa $out/bin/chikuwa
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "A sidebar TUI for monitoring multiple AI agents in tmux sessions";
+    homepage = "https://github.com/nownabe/chikuwa";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+    mainProgram = "chikuwa";
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
## Summary
- Add custom Nix package for chikuwa v0.1.4 (fetched from GitHub releases)
- Register chikuwa in the Nix overlay in `flake.nix`
- Add chikuwa to `home.packages` in `home.nix`

## Test plan
- [x] `hms` succeeds
- [x] `which chikuwa` resolves correctly