### PR TITLE
fix(claude): add all chikuwa hook events per README

### DIFF
--- a/programs/claude/settings.json
+++ b/programs/claude/settings.json
@@ -107,12 +107,16 @@
     "command": "~/.claude/scripts/statusline-command.sh"
   },
   "hooks": {
+    "SessionStart": [{"hooks": [{"type": "command", "command": "chikuwa hook"}]}],
     "UserPromptSubmit": [{"hooks": [{"type": "command", "command": "chikuwa hook"}]}],
     "PreToolUse": [{"hooks": [{"type": "command", "command": "chikuwa hook"}]}],
-    "Stop": [{"hooks": [{"type": "command", "command": "chikuwa hook"}]}],
+    "PostToolUse": [{"hooks": [{"type": "command", "command": "chikuwa hook"}]}],
+    "PostToolUseFailure": [{"hooks": [{"type": "command", "command": "chikuwa hook"}]}],
     "PermissionRequest": [{"hooks": [{"type": "command", "command": "chikuwa hook"}]}],
     "Notification": [{"hooks": [{"type": "command", "command": "chikuwa hook"}]}],
-    "SessionStart": [{"hooks": [{"type": "command", "command": "chikuwa hook"}]}],
+    "Stop": [{"hooks": [{"type": "command", "command": "chikuwa hook"}]}],
+    "SubagentStart": [{"hooks": [{"type": "command", "command": "chikuwa hook"}]}],
+    "SubagentStop": [{"hooks": [{"type": "command", "command": "chikuwa hook"}]}],
     "SessionEnd": [{"hooks": [{"type": "command", "command": "chikuwa hook"}]}]
   }
 }


### PR DESCRIPTION
## Summary
- Add missing chikuwa hook events: `PostToolUse`, `PostToolUseFailure`, `SubagentStart`, `SubagentStop`
- Reorder hooks to match the official README order from https://github.com/nownabe/chikuwa

## Test plan
- [ ] Run `hms` to apply the configuration
- [ ] Verify chikuwa monitors all hook events correctly