### PR TITLE
feat(claude): add @nownabe/claude-hooks from base plugin

### DIFF
--- a/programs/claude/settings.json
+++ b/programs/claude/settings.json
@@ -108,10 +108,17 @@
   },
   "hooks": {
     "UserPromptSubmit": [{"hooks": [{"type": "command", "command": "chikuwa hook"}]}],
-    "PreToolUse": [{"hooks": [{"type": "command", "command": "chikuwa hook"}]}],
+    "PreToolUse": [
+      {"hooks": [{"type": "command", "command": "chikuwa hook"}]},
+      {"matcher": "Bash", "hooks": [{"type": "command", "command": "bunx @nownabe/claude-hooks pre-bash"}]}
+    ],
     "Stop": [{"hooks": [{"type": "command", "command": "chikuwa hook"}]}],
     "PermissionRequest": [{"hooks": [{"type": "command", "command": "chikuwa hook"}]}],
-    "Notification": [{"hooks": [{"type": "command", "command": "chikuwa hook"}]}],
+    "Notification": [
+      {"hooks": [{"type": "command", "command": "chikuwa hook"}]},
+      {"matcher": "idle_prompt", "hooks": [{"type": "command", "command": "bunx @nownabe/claude-hooks notification", "async": true, "timeout": 30}]},
+      {"matcher": "permission_prompt", "hooks": [{"type": "command", "command": "bunx @nownabe/claude-hooks notification", "async": true, "timeout": 30}]}
+    ],
     "SessionStart": [{"hooks": [{"type": "command", "command": "chikuwa hook"}]}],
     "SessionEnd": [{"hooks": [{"type": "command", "command": "chikuwa hook"}]}]
   }


### PR DESCRIPTION
## Summary
- Add `@nownabe/claude-hooks` hooks from the base plugin (`nownabe/claude` repo)
- PreToolUse: `pre-bash` hook with `Bash` matcher
- Notification: `notification` hook with `idle_prompt` and `permission_prompt` matchers (async, 30s timeout)
- Existing chikuwa hooks are preserved alongside the new hooks

## Test plan
- [ ] Verify `hms` applies successfully
- [ ] Verify PreToolUse `pre-bash` hook fires on Bash tool use
- [ ] Verify Notification hooks fire on idle and permission prompts