### PR TITLE
fix(claude): forbid $(cat in git commit and gh pr commands

### DIFF
--- a/programs/claude/nownabe-claude-hooks.json
+++ b/programs/claude/nownabe-claude-hooks.json
@@ -10,6 +10,14 @@
       "git -C *": {
         "reason": "`git -C` is forbidden.",
         "suggestion": "Run git commands from the target directory directly instead of using `git -C`."
+      },
+      "git commit *$(cat*": {
+        "reason": "`$(cat` in `git commit` is forbidden.",
+        "suggestion": "Pass the commit message directly with `-m \"message\"` instead of using `$(cat <<'EOF' ...)`."
+      },
+      "gh pr *$(cat*": {
+        "reason": "`$(cat` in `gh pr` is forbidden.",
+        "suggestion": "Pass arguments directly with `--title \"title\" --body \"body\"` instead of using `$(cat <<'EOF' ...)`."
       }
     }
   }

--- a/programs/claude/nownabe-claude-hooks.json
+++ b/programs/claude/nownabe-claude-hooks.json
@@ -11,11 +11,13 @@
         "reason": "`git -C` is forbidden.",
         "suggestion": "Run git commands from the target directory directly instead of using `git -C`."
       },
-      "git commit *$(cat*": {
+      "\\bgit\\s+commit\\b.*\\$\\(cat\\b": {
+        "type": "regex",
         "reason": "`$(cat` in `git commit` is forbidden.",
         "suggestion": "Pass the commit message directly with `-m \"message\"` instead of using `$(cat <<'EOF' ...)`."
       },
-      "gh pr *$(cat*": {
+      "\\bgh\\s+pr\\b.*\\$\\(cat\\b": {
+        "type": "regex",
         "reason": "`$(cat` in `gh pr` is forbidden.",
         "suggestion": "Pass arguments directly with `--title \"title\" --body \"body\"` instead of using `$(cat <<'EOF' ...)`."
       }


### PR DESCRIPTION
## Summary
- Add forbidden patterns to `nownabe-claude-hooks.json` for `$(cat` usage in `git commit` and `gh pr` commands
- `git commit *$(cat*` — suggests using `-m "message"` directly
- `gh pr *$(cat*` — suggests using `--title` / `--body` directly

## Test plan
- [ ] Verify `hms` applies successfully
- [ ] Verify `git commit -m "$(cat <<'EOF' ... EOF)"` is blocked by pre-bash hook
- [ ] Verify `gh pr create --body "$(cat <<'EOF' ... EOF)"` is blocked by pre-bash hook