### PR TITLE
feat(claude): add read-only access to ~/src/github.com/nownabe/claude

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,12 @@
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "permissions": {
     "defaultMode": "acceptEdits",
+    "additionalDirectories": [
+      "~/src/github.com/nownabe/claude"
+    ],
+    "deny": [
+      "Edit(~/src/github.com/nownabe/claude/**)"
+    ],
     "allow": [
       "Bash(gh api repos/nownabe/claude/contents*)",
       "Bash(gh issue view:*)",


### PR DESCRIPTION
## Summary
- Add `~/src/github.com/nownabe/claude` to `additionalDirectories` in Claude Code settings
- Add `deny` rule for `Edit` to enforce read-only access

## Test plan
- [ ] Verify Claude Code can read files in `~/src/github.com/nownabe/claude`
- [ ] Verify Claude Code cannot edit files in `~/src/github.com/nownabe/claude`