### PR TITLE
fix(nvim): shorten tmux window label with git-relative path and Neovim icon

### DIFF
--- a/programs/nvim/config/lua/plugins/astrocore.lua
+++ b/programs/nvim/config/lua/plugins/astrocore.lua
@@ -7,6 +7,7 @@ return {
         relativenumber = false,
         spell = true,
         wrap = true,
+        titlestring = "%{v:lua.nvim_title()}",
       },
     },
   },
@@ -16,5 +17,17 @@ return {
       virtual_text = false,
       virtual_lines = true,
     })
+
+    function _G.nvim_title()
+      local filepath = vim.fn.expand("%:p")
+      if filepath == "" then return "\u{e7c5} [No Name]" end
+      local dir = vim.fn.expand("%:p:h")
+      local found = vim.fs.find(".git", { upward = true, path = dir })
+      if #found > 0 then
+        local root = vim.fn.fnamemodify(found[1], ":h") .. "/"
+        if filepath:sub(1, #root) == root then return "\u{e7c5} " .. filepath:sub(#root + 1) end
+      end
+      return "\u{e7c5} " .. vim.fn.expand("%:t")
+    end
   end,
 }


### PR DESCRIPTION
## Summary
- Set nvim `titlestring` to show Neovim icon (U+E7C5) and file path relative to git repository root
- Uses `vim.fs.find` to locate nearest `.git` (file or directory), supporting both regular repos and worktrees
- Falls back to filename only for files outside a git repository

## Test plan
- [ ] Open a file in nvim inside a git repo and verify the tmux window label shows the Neovim icon and repo-relative path
- [ ] Open a file in a git worktree and verify the path is relative to the worktree root
- [ ] Open a file outside a git repo and verify only the filename is shown