### PR TITLE
feat(zsh): add NerdFont terminal icon to tmux window title

### DIFF
--- a/programs/zsh/config/title.zsh
+++ b/programs/zsh/config/title.zsh
@@ -21,7 +21,7 @@ _short_path() {
 }
 
 _set_terminal_title() {
-  print -Pn "\e]2;$(_short_path)\a"
+  print -Pn "\e]2;\ue795 $(_short_path)\a"
 }
 
 autoload -Uz add-zsh-hook


### PR DESCRIPTION
## Summary
- Add NerdFont terminal icon (`\ue795`) prefix to zsh terminal title in tmux window
- Neovim already shows its icon (`\ue7c5`), now zsh shows a terminal icon too

## Test plan
- [ ] Open a new zsh shell in tmux and verify the terminal icon appears in the window title
- [ ] Confirm Neovim windows still show the Neovim icon