### PR TITLE
feat(zsh): show git-root-relative path in tmux window title

### DIFF
--- a/programs/zsh/config/title.zsh
+++ b/programs/zsh/config/title.zsh
@@ -1,27 +1,36 @@
-# Terminal title: show shortened path (e.g., /h/n/s/g/n/dotfiles)
-# Each intermediate directory is abbreviated to its first character,
-# while the last component is shown in full.
-_short_path() {
-  local dir="${PWD/#$HOME/~}"
-  local parts=("${(@s:/:)dir}")
-  local result=""
-  local last=${#parts}
+# Terminal title: show git-root-relative path with root dir name.
+# In a git repo: "dotfiles" (at root) or "dotfiles/programs/zsh" (in subdir)
+# Outside a git repo: shortened path (e.g., ~/s/g/n/dotfiles)
+_title_path() {
+  local toplevel
+  toplevel=$(git rev-parse --show-toplevel 2>/dev/null)
+  if [[ -n "$toplevel" ]]; then
+    local root_name="${toplevel:t}"
+    local rel="${PWD#$toplevel}"
+    echo "${root_name}${rel}"
+  else
+    # Fallback: shortened path for non-git directories
+    local dir="${PWD/#$HOME/~}"
+    local parts=("${(@s:/:)dir}")
+    local result=""
+    local last=${#parts}
 
-  for i in {1..$last}; do
-    if [[ $i -eq $last ]]; then
-      result+="${parts[$i]}"
-    elif [[ -n "${parts[$i]}" ]]; then
-      result+="${parts[$i][1]}/"
-    else
-      result+="/"
-    fi
-  done
+    for i in {1..$last}; do
+      if [[ $i -eq $last ]]; then
+        result+="${parts[$i]}"
+      elif [[ -n "${parts[$i]}" ]]; then
+        result+="${parts[$i][1]}/"
+      else
+        result+="/"
+      fi
+    done
 
-  echo "$result"
+    echo "$result"
+  fi
 }
 
 _set_terminal_title() {
-  print -Pn "\e]2;\ue795 $(_short_path)\a"
+  print -Pn "\e]2;\ue795 $(_title_path)\a"
 }
 
 autoload -Uz add-zsh-hook


### PR DESCRIPTION
## Summary
- Show git-root-relative path in zsh terminal title (e.g., `dotfiles` at root, `dotfiles/programs/zsh` in subdir)
- Fall back to shortened path for non-git directories (e.g., `~/s/g/n/other`)
- Matches Neovim's approach of showing git-relative paths

## Test plan
- [ ] In a git repo root: title shows ` dotfiles`
- [ ] In a git repo subdir: title shows ` dotfiles/programs/zsh`
- [ ] Outside a git repo: title shows shortened path like ` ~/s/g/n/dir`