### PR TITLE
chore(nix): update chikuwa to v0.1.6

### DIFF
--- a/packages/chikuwa.nix
+++ b/packages/chikuwa.nix
@@ -10,7 +10,7 @@ stdenvNoCC.mkDerivation rec {
 
   src = fetchurl {
     url = "https://github.com/nownabe/chikuwa/releases/download/v${version}/chikuwa-x86_64-unknown-linux-gnu.tar.gz";
-    hash = "sha256-evSPy8zzv/NY3msnrDJWcCfAE1DDxgmi4g8woy1Pcyk=";
+    hash = "sha256-JhYtKjYt3LfaqRzzTxCCWCf+FEnjfGFbuXjRiPq39kM=";
   };
 
   sourceRoot = ".";

--- a/packages/chikuwa.nix
+++ b/packages/chikuwa.nix
@@ -6,11 +6,11 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "chikuwa";
-  version = "0.1.4";
+  version = "0.1.6";
 
   src = fetchurl {
     url = "https://github.com/nownabe/chikuwa/releases/download/v${version}/chikuwa-x86_64-unknown-linux-gnu.tar.gz";
-    hash = "sha256-omY+Y3HXAOUfNvQ4fcKMNohewXb4ye1N1Erddo3ufiM=";
+    hash = "sha256-evSPy8zzv/NY3msnrDJWcCfAE1DDxgmi4g8woy1Pcyk=";
   };
 
   sourceRoot = ".";


### PR DESCRIPTION
## Summary
- Update chikuwa package from v0.1.4 to v0.1.6

## Test plan
- [ ] Run `hms` to apply and verify chikuwa v0.1.6 is installed
- [ ] Run `chikuwa --version` to confirm version