### PR TITLE
chore(nix): update flake inputs and aqua to v2.57.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772330611,
-        "narHash": "sha256-UZjPc/d5XRxvjDbk4veAO4XFdvx6BUum2l40V688Xq8=",
+        "lastModified": 1773264496,
+        "narHash": "sha256-uwFY0+UfaGEo6205ixeBjplZxHWr56UQef+MtmJ0PW0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "58fd7ff0eec2cda43e705c4c0585729ec471d400",
+        "rev": "32f78141a98098efed490842923b25ecb93b9b9f",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1772173633,
-        "narHash": "sha256-MOH58F4AIbCkh6qlQcwMycyk5SWvsqnS/TCfnqDlpj4=",
+        "lastModified": 1773110118,
+        "narHash": "sha256-mPAG8phMbCReKSiKAijjjd3v7uVcJOQ75gSjGJjt/Rk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c0f3d81a7ddbc2b1332be0d8481a672b4f6004d6",
+        "rev": "e607cb5360ff1234862ac9f8839522becb853bb9",
         "type": "github"
       },
       "original": {

--- a/packages/aqua.nix
+++ b/packages/aqua.nix
@@ -6,11 +6,11 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "aqua";
-  version = "2.56.7";
+  version = "2.57.0";
 
   src = fetchurl {
     url = "https://github.com/aquaproj/aqua/releases/download/v${version}/aqua_linux_amd64.tar.gz";
-    hash = "sha256-KMZjNSZUUawNNKNk5Xg25tc+9Vy7lpgmXOPuK5fxx8A=";
+    hash = "sha256-BCFG/sa3qubtYSP9UDMUR0Ssqpr6R23ZpH4qrVDV1cY=";
   };
 
   sourceRoot = ".";


### PR DESCRIPTION
## Summary
- Update nixpkgs: c0f3d81 (2026-02-27) → e607cb5 (2026-03-10)
- Update home-manager: 58fd7ff (2026-03-01) → 32f7814 (2026-03-11)
- Update aqua: v2.56.7 → v2.57.0
- chikuwa is already at latest (v0.1.8)

## Test plan
- [x] `nix build` succeeds