### PR TITLE
feat(nix): add JDK to home packages

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -22,6 +22,7 @@
 
       # Languages & runtimes
       go
+      jdk
       lua
       nodejs
       python3


### PR DESCRIPTION
## Summary
- Add JDK (OpenJDK 21) to Nix Home Manager packages

## Test plan
- [x] Run `hms` to apply configuration
- [x] Verify `java -version` and `javac -version` work