### PR TITLE
feat(nvim): add Bash language support

### DIFF
--- a/programs/nvim/config/lua/plugins/lang/bash.lua
+++ b/programs/nvim/config/lua/plugins/lang/bash.lua
@@ -1,0 +1,52 @@
+-- Bash language support
+-- Based on https://github.com/AstroNvim/astrocommunity/blob/main/lua/astrocommunity/pack/bash/init.lua
+
+return {
+  {
+    "nvim-treesitter/nvim-treesitter",
+    optional = true,
+    opts = function(_, opts)
+      if opts.ensure_installed ~= "all" then
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "bash" })
+      end
+    end,
+  },
+  {
+    "williamboman/mason-lspconfig.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "bashls" })
+    end,
+  },
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, {
+        "bash-language-server",
+        "shellcheck",
+        "shfmt",
+      })
+    end,
+  },
+  {
+    "stevearc/conform.nvim",
+    optional = true,
+    opts = {
+      formatters_by_ft = {
+        sh = { "shfmt" },
+        bash = { "shfmt" },
+      },
+    },
+  },
+  {
+    "mfussenegger/nvim-lint",
+    optional = true,
+    opts = {
+      linters_by_ft = {
+        sh = { "shellcheck" },
+        bash = { "shellcheck" },
+      },
+    },
+  },
+}


### PR DESCRIPTION
## Summary
- Add Bash language support config at `programs/nvim/config/lua/plugins/lang/bash.lua`
- LSP: `bashls` via mason-lspconfig
- Treesitter: `bash` parser
- Formatter: `shfmt` via conform.nvim (for `sh` and `bash` filetypes)
- Linter: `shellcheck` via nvim-lint (for `sh` and `bash` filetypes)
- Mason tools: `bash-language-server`, `shellcheck`, `shfmt`
- Skipped DAP (bash-debug-adapter) as shell script debugging is rarely needed

Closes #120

## Test plan
- [ ] Run `hms` to apply configuration
- [ ] Open a `.sh` file and verify bashls starts
- [ ] Verify shfmt formatting works on save
- [ ] Verify shellcheck diagnostics appear for issues