### PR TITLE
feat(nvim): add Terraform language support

### DIFF
--- a/programs/nvim/config/lua/plugins/lang/terraform.lua
+++ b/programs/nvim/config/lua/plugins/lang/terraform.lua
@@ -1,0 +1,51 @@
+-- Terraform language support
+-- Based on https://github.com/AstroNvim/astrocommunity/blob/main/lua/astrocommunity/pack/terraform/init.lua
+
+return {
+  {
+    "nvim-treesitter/nvim-treesitter",
+    optional = true,
+    opts = function(_, opts)
+      if opts.ensure_installed ~= "all" then
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "terraform", "hcl" })
+      end
+    end,
+  },
+  {
+    "williamboman/mason-lspconfig.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "terraformls" })
+    end,
+  },
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, {
+        "terraform-ls",
+        "tflint",
+      })
+    end,
+  },
+  {
+    "stevearc/conform.nvim",
+    optional = true,
+    opts = {
+      formatters_by_ft = {
+        terraform = { "terraform_fmt" },
+        ["terraform-vars"] = { "terraform_fmt" },
+      },
+    },
+  },
+  {
+    "mfussenegger/nvim-lint",
+    optional = true,
+    opts = {
+      linters_by_ft = {
+        terraform = { "tflint" },
+        ["terraform-vars"] = { "tflint" },
+      },
+    },
+  },
+}


### PR DESCRIPTION
## Summary
- Add Terraform language support with LSP, treesitter, formatter, and linter
- Configure `terraformls` for LSP via mason-lspconfig
- Add `terraform` and `hcl` treesitter grammars
- Set up `terraform_fmt` formatter via conform.nvim for `terraform` and `terraform-vars` filetypes
- Configure `tflint` linter via nvim-lint
- Skip `tfsec` as it has been merged into `trivy` and security scanning is better suited for CI/CD

Closes #135

## Test plan
- [ ] Run `hms` to apply the configuration
- [ ] Open a `.tf` file and verify LSP attaches (`terraformls`)
- [ ] Verify treesitter highlighting works for `.tf` and `.hcl` files
- [ ] Verify formatting with `terraform fmt` on save
- [ ] Verify `tflint` diagnostics appear