### PR TITLE
feat(nvim): add language support packs for remaining languages

### DIFF
--- a/programs/nvim/config/lua/plugins/lang/astro.lua
+++ b/programs/nvim/config/lua/plugins/lang/astro.lua
@@ -1,0 +1,37 @@
+-- Astro language support
+-- LSP: astro
+
+return {
+  {
+    "AstroNvim/astrolsp",
+    optional = true,
+    opts = function(_, opts)
+      opts.servers = require("astrocore").list_insert_unique(opts.servers or {}, { "astro" })
+    end,
+  },
+  {
+    "nvim-treesitter/nvim-treesitter",
+    optional = true,
+    opts = function(_, opts)
+      if opts.ensure_installed ~= "all" then
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "astro" })
+      end
+    end,
+  },
+  {
+    "williamboman/mason-lspconfig.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "astro" })
+    end,
+  },
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, {
+        "astro-language-server",
+      })
+    end,
+  },
+}

--- a/programs/nvim/config/lua/plugins/lang/cue.lua
+++ b/programs/nvim/config/lua/plugins/lang/cue.lua
@@ -1,0 +1,37 @@
+-- CUE language support
+-- LSP: dagger (cuelsp)
+
+return {
+  {
+    "AstroNvim/astrolsp",
+    optional = true,
+    opts = function(_, opts)
+      opts.servers = require("astrocore").list_insert_unique(opts.servers or {}, { "dagger" })
+    end,
+  },
+  {
+    "nvim-treesitter/nvim-treesitter",
+    optional = true,
+    opts = function(_, opts)
+      if opts.ensure_installed ~= "all" then
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "cue" })
+      end
+    end,
+  },
+  {
+    "williamboman/mason-lspconfig.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "dagger" })
+    end,
+  },
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, {
+        "cuelsp",
+      })
+    end,
+  },
+}

--- a/programs/nvim/config/lua/plugins/lang/docker.lua
+++ b/programs/nvim/config/lua/plugins/lang/docker.lua
@@ -1,0 +1,55 @@
+-- Docker language support
+-- LSP: dockerls, docker_compose_language_service
+-- Linter: hadolint
+
+return {
+  {
+    "AstroNvim/astrolsp",
+    optional = true,
+    opts = function(_, opts)
+      opts.servers = require("astrocore").list_insert_unique(
+        opts.servers or {},
+        { "dockerls", "docker_compose_language_service" }
+      )
+    end,
+  },
+  {
+    "nvim-treesitter/nvim-treesitter",
+    optional = true,
+    opts = function(_, opts)
+      if opts.ensure_installed ~= "all" then
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "dockerfile" })
+      end
+    end,
+  },
+  {
+    "williamboman/mason-lspconfig.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(
+        opts.ensure_installed,
+        { "dockerls", "docker_compose_language_service" }
+      )
+    end,
+  },
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, {
+        "dockerfile-language-server",
+        "docker-compose-language-service",
+        "hadolint",
+      })
+    end,
+  },
+  {
+    "mfussenegger/nvim-lint",
+    optional = true,
+    opts = {
+      linters_by_ft = {
+        dockerfile = { "hadolint" },
+      },
+    },
+  },
+}

--- a/programs/nvim/config/lua/plugins/lang/html-css.lua
+++ b/programs/nvim/config/lua/plugins/lang/html-css.lua
@@ -1,0 +1,40 @@
+-- HTML/CSS language support
+-- LSP: html, cssls, emmet_ls
+
+return {
+  {
+    "AstroNvim/astrolsp",
+    optional = true,
+    opts = function(_, opts)
+      opts.servers = require("astrocore").list_insert_unique(opts.servers or {}, { "html", "cssls", "emmet_ls" })
+    end,
+  },
+  {
+    "nvim-treesitter/nvim-treesitter",
+    optional = true,
+    opts = function(_, opts)
+      if opts.ensure_installed ~= "all" then
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "html", "css" })
+      end
+    end,
+  },
+  {
+    "williamboman/mason-lspconfig.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed =
+        require("astrocore").list_insert_unique(opts.ensure_installed, { "html", "cssls", "emmet_ls" })
+    end,
+  },
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, {
+        "html-lsp",
+        "css-lsp",
+        "emmet-ls",
+      })
+    end,
+  },
+}

--- a/programs/nvim/config/lua/plugins/lang/json.lua
+++ b/programs/nvim/config/lua/plugins/lang/json.lua
@@ -1,0 +1,50 @@
+-- JSON language support
+-- LSP: jsonls with schemastore
+
+return {
+  {
+    "b0o/schemastore.nvim",
+    lazy = true,
+  },
+  {
+    "AstroNvim/astrolsp",
+    optional = true,
+    opts = function(_, opts)
+      opts.servers = require("astrocore").list_insert_unique(opts.servers or {}, { "jsonls" })
+      opts.config = vim.tbl_deep_extend("force", opts.config or {}, {
+        jsonls = {
+          on_new_config = function(config)
+            if not config.settings.json then config.settings.json = {} end
+            config.settings.json.schemas = require("schemastore").json.schemas()
+            config.settings.json.validate = { enable = true }
+          end,
+        },
+      })
+    end,
+  },
+  {
+    "nvim-treesitter/nvim-treesitter",
+    optional = true,
+    opts = function(_, opts)
+      if opts.ensure_installed ~= "all" then
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "json", "jsonc" })
+      end
+    end,
+  },
+  {
+    "williamboman/mason-lspconfig.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "jsonls" })
+    end,
+  },
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, {
+        "json-lsp",
+      })
+    end,
+  },
+}

--- a/programs/nvim/config/lua/plugins/lang/markdown.lua
+++ b/programs/nvim/config/lua/plugins/lang/markdown.lua
@@ -1,0 +1,38 @@
+-- Markdown language support
+-- LSP: marksman
+
+return {
+  {
+    "AstroNvim/astrolsp",
+    optional = true,
+    opts = function(_, opts)
+      opts.servers = require("astrocore").list_insert_unique(opts.servers or {}, { "marksman" })
+    end,
+  },
+  {
+    "nvim-treesitter/nvim-treesitter",
+    optional = true,
+    opts = function(_, opts)
+      if opts.ensure_installed ~= "all" then
+        opts.ensure_installed =
+          require("astrocore").list_insert_unique(opts.ensure_installed, { "markdown", "markdown_inline" })
+      end
+    end,
+  },
+  {
+    "williamboman/mason-lspconfig.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "marksman" })
+    end,
+  },
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, {
+        "marksman",
+      })
+    end,
+  },
+}

--- a/programs/nvim/config/lua/plugins/lang/mdx.lua
+++ b/programs/nvim/config/lua/plugins/lang/mdx.lua
@@ -1,0 +1,28 @@
+-- MDX language support
+-- LSP: mdx_analyzer
+
+return {
+  {
+    "AstroNvim/astrolsp",
+    optional = true,
+    opts = function(_, opts)
+      opts.servers = require("astrocore").list_insert_unique(opts.servers or {}, { "mdx_analyzer" })
+    end,
+  },
+  {
+    "williamboman/mason-lspconfig.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "mdx_analyzer" })
+    end,
+  },
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, {
+        "mdx-analyzer",
+      })
+    end,
+  },
+}

--- a/programs/nvim/config/lua/plugins/lang/proto.lua
+++ b/programs/nvim/config/lua/plugins/lang/proto.lua
@@ -1,0 +1,56 @@
+-- Protocol Buffers language support
+-- LSP: buf_ls
+-- Formatter: buf, Linter: buf_lint
+
+return {
+  {
+    "AstroNvim/astrolsp",
+    optional = true,
+    opts = function(_, opts)
+      opts.servers = require("astrocore").list_insert_unique(opts.servers or {}, { "buf_ls" })
+    end,
+  },
+  {
+    "nvim-treesitter/nvim-treesitter",
+    optional = true,
+    opts = function(_, opts)
+      if opts.ensure_installed ~= "all" then
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "proto" })
+      end
+    end,
+  },
+  {
+    "williamboman/mason-lspconfig.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "buf_ls" })
+    end,
+  },
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, {
+        "buf",
+      })
+    end,
+  },
+  {
+    "stevearc/conform.nvim",
+    optional = true,
+    opts = {
+      formatters_by_ft = {
+        proto = { "buf" },
+      },
+    },
+  },
+  {
+    "mfussenegger/nvim-lint",
+    optional = true,
+    opts = {
+      linters_by_ft = {
+        proto = { "buf_lint" },
+      },
+    },
+  },
+}

--- a/programs/nvim/config/lua/plugins/lang/python.lua
+++ b/programs/nvim/config/lua/plugins/lang/python.lua
@@ -1,0 +1,70 @@
+-- Python language support
+-- LSP: basedpyright, Formatter/Linter: ruff
+
+return {
+  {
+    "AstroNvim/astrolsp",
+    optional = true,
+    opts = function(_, opts)
+      opts.servers = require("astrocore").list_insert_unique(opts.servers or {}, { "basedpyright", "ruff" })
+      opts.config = vim.tbl_deep_extend("force", opts.config or {}, {
+        basedpyright = {
+          settings = {
+            basedpyright = {
+              disableOrganizeImports = true, -- use ruff instead
+              analysis = {
+                autoImportCompletions = true,
+                diagnosticMode = "openFilesOnly",
+              },
+            },
+          },
+        },
+      })
+    end,
+  },
+  {
+    "nvim-treesitter/nvim-treesitter",
+    optional = true,
+    opts = function(_, opts)
+      if opts.ensure_installed ~= "all" then
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "python" })
+      end
+    end,
+  },
+  {
+    "williamboman/mason-lspconfig.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed =
+        require("astrocore").list_insert_unique(opts.ensure_installed, { "basedpyright", "ruff" })
+    end,
+  },
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, {
+        "basedpyright",
+        "ruff",
+      })
+    end,
+  },
+  {
+    "stevearc/conform.nvim",
+    optional = true,
+    opts = {
+      formatters_by_ft = {
+        python = { "ruff_organize_imports", "ruff_format" },
+      },
+    },
+  },
+  {
+    "mfussenegger/nvim-lint",
+    optional = true,
+    opts = {
+      linters_by_ft = {
+        python = { "ruff" },
+      },
+    },
+  },
+}

--- a/programs/nvim/config/lua/plugins/lang/rego.lua
+++ b/programs/nvim/config/lua/plugins/lang/rego.lua
@@ -1,0 +1,46 @@
+-- Rego language support
+-- LSP: regols
+
+return {
+  {
+    "AstroNvim/astrolsp",
+    optional = true,
+    opts = function(_, opts)
+      opts.servers = require("astrocore").list_insert_unique(opts.servers or {}, { "regols" })
+    end,
+  },
+  {
+    "nvim-treesitter/nvim-treesitter",
+    optional = true,
+    opts = function(_, opts)
+      if opts.ensure_installed ~= "all" then
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "rego" })
+      end
+    end,
+  },
+  {
+    "williamboman/mason-lspconfig.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "regols" })
+    end,
+  },
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, {
+        "regols",
+      })
+    end,
+  },
+  {
+    "mfussenegger/nvim-lint",
+    optional = true,
+    opts = {
+      linters_by_ft = {
+        rego = { "opa_check" },
+      },
+    },
+  },
+}

--- a/programs/nvim/config/lua/plugins/lang/ruby.lua
+++ b/programs/nvim/config/lua/plugins/lang/ruby.lua
@@ -1,0 +1,37 @@
+-- Ruby language support
+-- LSP: ruby-lsp (Shopify)
+
+return {
+  {
+    "AstroNvim/astrolsp",
+    optional = true,
+    opts = function(_, opts)
+      opts.servers = require("astrocore").list_insert_unique(opts.servers or {}, { "ruby_lsp" })
+    end,
+  },
+  {
+    "nvim-treesitter/nvim-treesitter",
+    optional = true,
+    opts = function(_, opts)
+      if opts.ensure_installed ~= "all" then
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "ruby" })
+      end
+    end,
+  },
+  {
+    "williamboman/mason-lspconfig.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "ruby_lsp" })
+    end,
+  },
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, {
+        "ruby-lsp",
+      })
+    end,
+  },
+}

--- a/programs/nvim/config/lua/plugins/lang/rust.lua
+++ b/programs/nvim/config/lua/plugins/lang/rust.lua
@@ -1,0 +1,56 @@
+-- Rust language support
+-- LSP: rust_analyzer
+
+return {
+  {
+    "AstroNvim/astrolsp",
+    optional = true,
+    opts = function(_, opts)
+      opts.servers = require("astrocore").list_insert_unique(opts.servers or {}, { "rust_analyzer" })
+      opts.config = vim.tbl_deep_extend("force", opts.config or {}, {
+        rust_analyzer = {
+          settings = {
+            ["rust-analyzer"] = {
+              checkOnSave = {
+                command = "clippy",
+              },
+              inlayHints = {
+                bindingModeHints = { enable = true },
+                closureReturnTypeHints = { enable = "always" },
+                lifetimeElisionHints = { enable = "always" },
+              },
+              completion = {
+                postfix = { enable = true },
+              },
+            },
+          },
+        },
+      })
+    end,
+  },
+  {
+    "nvim-treesitter/nvim-treesitter",
+    optional = true,
+    opts = function(_, opts)
+      if opts.ensure_installed ~= "all" then
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "rust" })
+      end
+    end,
+  },
+  {
+    "williamboman/mason-lspconfig.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "rust_analyzer" })
+    end,
+  },
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, {
+        "rust-analyzer",
+      })
+    end,
+  },
+}

--- a/programs/nvim/config/lua/plugins/lang/tailwindcss.lua
+++ b/programs/nvim/config/lua/plugins/lang/tailwindcss.lua
@@ -1,0 +1,28 @@
+-- TailwindCSS language support
+-- LSP: tailwindcss
+
+return {
+  {
+    "AstroNvim/astrolsp",
+    optional = true,
+    opts = function(_, opts)
+      opts.servers = require("astrocore").list_insert_unique(opts.servers or {}, { "tailwindcss" })
+    end,
+  },
+  {
+    "williamboman/mason-lspconfig.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "tailwindcss" })
+    end,
+  },
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, {
+        "tailwindcss-language-server",
+      })
+    end,
+  },
+}

--- a/programs/nvim/config/lua/plugins/lang/toml.lua
+++ b/programs/nvim/config/lua/plugins/lang/toml.lua
@@ -1,0 +1,37 @@
+-- TOML language support
+-- LSP: taplo (includes formatting)
+
+return {
+  {
+    "AstroNvim/astrolsp",
+    optional = true,
+    opts = function(_, opts)
+      opts.servers = require("astrocore").list_insert_unique(opts.servers or {}, { "taplo" })
+    end,
+  },
+  {
+    "nvim-treesitter/nvim-treesitter",
+    optional = true,
+    opts = function(_, opts)
+      if opts.ensure_installed ~= "all" then
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "toml" })
+      end
+    end,
+  },
+  {
+    "williamboman/mason-lspconfig.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "taplo" })
+    end,
+  },
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, {
+        "taplo",
+      })
+    end,
+  },
+}

--- a/programs/nvim/config/lua/plugins/lang/yaml.lua
+++ b/programs/nvim/config/lua/plugins/lang/yaml.lua
@@ -1,0 +1,59 @@
+-- YAML language support
+-- LSP: yamlls with schemastore
+
+return {
+  {
+    "b0o/schemastore.nvim",
+    lazy = true,
+  },
+  {
+    "AstroNvim/astrolsp",
+    optional = true,
+    opts = function(_, opts)
+      opts.servers = require("astrocore").list_insert_unique(opts.servers or {}, { "yamlls" })
+      opts.config = vim.tbl_deep_extend("force", opts.config or {}, {
+        yamlls = {
+          on_new_config = function(config)
+            if not config.settings.yaml then config.settings.yaml = {} end
+            config.settings.yaml.schemas =
+              vim.tbl_extend("force", config.settings.yaml.schemas or {}, require("schemastore").yaml.schemas())
+          end,
+          settings = {
+            yaml = {
+              validate = true,
+              schemaStore = {
+                enable = false, -- use schemastore.nvim instead
+                url = "",
+              },
+            },
+          },
+        },
+      })
+    end,
+  },
+  {
+    "nvim-treesitter/nvim-treesitter",
+    optional = true,
+    opts = function(_, opts)
+      if opts.ensure_installed ~= "all" then
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "yaml" })
+      end
+    end,
+  },
+  {
+    "williamboman/mason-lspconfig.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "yamlls" })
+    end,
+  },
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, {
+        "yaml-language-server",
+      })
+    end,
+  },
+}


### PR DESCRIPTION
## Summary
- Add Python language support (basedpyright + ruff for formatting/linting)
- Add Ruby language support (ruby-lsp)
- Add Rust language support (rust_analyzer with clippy check-on-save)
- Add HTML/CSS language support (html, cssls, emmet_ls)
- Add TailwindCSS language support (tailwindcss LSP)
- Add JSON language support (jsonls + schemastore.nvim)
- Add YAML language support (yamlls + schemastore.nvim)
- Add TOML language support (taplo)
- Add Markdown language support (marksman)
- Add MDX language support (mdx_analyzer)
- Add Docker language support (dockerls, docker-compose, hadolint linter)
- Add Protocol Buffers language support (buf_ls + buf formatter/linter)
- Add CUE language support (dagger/cuelsp)
- Add Rego language support (regols + opa_check linter)
- Add Astro language support (astro LSP)

Closes #123, closes #124, closes #125, closes #127, closes #128, closes #129, closes #130, closes #131, closes #132, closes #133, closes #134, closes #136, closes #137, closes #138, closes #139

## Test plan
- [ ] Run hms to apply Nix configuration
- [ ] Open Python file and verify basedpyright LSP attaches, ruff formatting/linting works
- [ ] Open Ruby file and verify ruby-lsp attaches
- [ ] Open Rust file and verify rust_analyzer attaches with clippy
- [ ] Open HTML/CSS files and verify LSP attaches
- [ ] Open JSON file and verify jsonls with schema completion works
- [ ] Open YAML file and verify yamlls with schema completion works
- [ ] Open TOML file and verify taplo LSP attaches
- [ ] Open Markdown file and verify marksman LSP attaches
- [ ] Open Dockerfile and verify dockerls attaches, hadolint linting works
- [ ] Open .proto file and verify buf_ls attaches
- [ ] Open .cue file and verify cuelsp attaches
- [ ] Open .rego file and verify regols attaches
- [ ] Open .astro file and verify astro LSP attaches