### PR TITLE
feat(nvim): add Python language support

### DIFF
--- a/programs/nvim/config/lua/plugins/lang/python.lua
+++ b/programs/nvim/config/lua/plugins/lang/python.lua
@@ -1,25 +1,12 @@
 -- Python language support
--- LSP: basedpyright, Formatter/Linter: ruff
+-- LSP: ty (type checker), ruff (formatter/linter)
 
 return {
   {
     "AstroNvim/astrolsp",
     optional = true,
     opts = function(_, opts)
-      opts.servers = require("astrocore").list_insert_unique(opts.servers or {}, { "basedpyright", "ruff" })
-      opts.config = vim.tbl_deep_extend("force", opts.config or {}, {
-        basedpyright = {
-          settings = {
-            basedpyright = {
-              disableOrganizeImports = true, -- use ruff instead
-              analysis = {
-                autoImportCompletions = true,
-                diagnosticMode = "openFilesOnly",
-              },
-            },
-          },
-        },
-      })
+      opts.servers = require("astrocore").list_insert_unique(opts.servers or {}, { "ty", "ruff" })
     end,
   },
   {
@@ -35,8 +22,7 @@ return {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
     opts = function(_, opts)
-      opts.ensure_installed =
-        require("astrocore").list_insert_unique(opts.ensure_installed, { "basedpyright", "ruff" })
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "ty", "ruff" })
     end,
   },
   {
@@ -44,7 +30,7 @@ return {
     optional = true,
     opts = function(_, opts)
       opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, {
-        "basedpyright",
+        "ty",
         "ruff",
       })
     end,

--- a/programs/nvim/config/lua/plugins/lang/python.lua
+++ b/programs/nvim/config/lua/plugins/lang/python.lua
@@ -1,0 +1,70 @@
+-- Python language support
+-- LSP: basedpyright, Formatter/Linter: ruff
+
+return {
+  {
+    "AstroNvim/astrolsp",
+    optional = true,
+    opts = function(_, opts)
+      opts.servers = require("astrocore").list_insert_unique(opts.servers or {}, { "basedpyright", "ruff" })
+      opts.config = vim.tbl_deep_extend("force", opts.config or {}, {
+        basedpyright = {
+          settings = {
+            basedpyright = {
+              disableOrganizeImports = true, -- use ruff instead
+              analysis = {
+                autoImportCompletions = true,
+                diagnosticMode = "openFilesOnly",
+              },
+            },
+          },
+        },
+      })
+    end,
+  },
+  {
+    "nvim-treesitter/nvim-treesitter",
+    optional = true,
+    opts = function(_, opts)
+      if opts.ensure_installed ~= "all" then
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "python" })
+      end
+    end,
+  },
+  {
+    "williamboman/mason-lspconfig.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed =
+        require("astrocore").list_insert_unique(opts.ensure_installed, { "basedpyright", "ruff" })
+    end,
+  },
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, {
+        "basedpyright",
+        "ruff",
+      })
+    end,
+  },
+  {
+    "stevearc/conform.nvim",
+    optional = true,
+    opts = {
+      formatters_by_ft = {
+        python = { "ruff_organize_imports", "ruff_format" },
+      },
+    },
+  },
+  {
+    "mfussenegger/nvim-lint",
+    optional = true,
+    opts = {
+      linters_by_ft = {
+        python = { "ruff" },
+      },
+    },
+  },
+}


### PR DESCRIPTION
## Summary
- Add Python language support with ty (Astral) for type checking and ruff for formatting/linting
- ty: Rust-based Python type checker with built-in LSP server (beta, v0.0.23)
- ruff: formatting (ruff_format), import sorting (ruff_organize_imports), and linting
- Configure treesitter parser for Python

Closes #123