### PR TITLE
feat(nvim): add HTML/CSS language support

### DIFF
--- a/programs/nvim/config/lua/plugins/lang/html-css.lua
+++ b/programs/nvim/config/lua/plugins/lang/html-css.lua
@@ -1,0 +1,40 @@
+-- HTML/CSS language support
+-- LSP: html, cssls, emmet_ls
+
+return {
+  {
+    "AstroNvim/astrolsp",
+    optional = true,
+    opts = function(_, opts)
+      opts.servers = require("astrocore").list_insert_unique(opts.servers or {}, { "html", "cssls", "emmet_ls" })
+    end,
+  },
+  {
+    "nvim-treesitter/nvim-treesitter",
+    optional = true,
+    opts = function(_, opts)
+      if opts.ensure_installed ~= "all" then
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "html", "css" })
+      end
+    end,
+  },
+  {
+    "williamboman/mason-lspconfig.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed =
+        require("astrocore").list_insert_unique(opts.ensure_installed, { "html", "cssls", "emmet_ls" })
+    end,
+  },
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, {
+        "html-lsp",
+        "css-lsp",
+        "emmet-ls",
+      })
+    end,
+  },
+}

--- a/programs/nvim/config/lua/plugins/lang/html-css.lua
+++ b/programs/nvim/config/lua/plugins/lang/html-css.lua
@@ -1,12 +1,12 @@
 -- HTML/CSS language support
--- LSP: html, cssls
+-- LSP: html, cssls, Formatter: oxfmt
 
 return {
   {
     "AstroNvim/astrolsp",
     optional = true,
     opts = function(_, opts)
-      opts.servers = require("astrocore").list_insert_unique(opts.servers or {}, { "html", "cssls" })
+      opts.servers = require("astrocore").list_insert_unique(opts.servers or {}, { "html", "cssls", "oxfmt" })
     end,
   },
   {
@@ -23,7 +23,7 @@ return {
     optional = true,
     opts = function(_, opts)
       opts.ensure_installed =
-        require("astrocore").list_insert_unique(opts.ensure_installed, { "html", "cssls" })
+        require("astrocore").list_insert_unique(opts.ensure_installed, { "html", "cssls", "oxfmt" })
     end,
   },
   {
@@ -33,6 +33,7 @@ return {
       opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, {
         "html-lsp",
         "css-lsp",
+        "oxfmt",
       })
     end,
   },

--- a/programs/nvim/config/lua/plugins/lang/html-css.lua
+++ b/programs/nvim/config/lua/plugins/lang/html-css.lua
@@ -1,12 +1,12 @@
 -- HTML/CSS language support
--- LSP: html, cssls, emmet_ls
+-- LSP: html, cssls
 
 return {
   {
     "AstroNvim/astrolsp",
     optional = true,
     opts = function(_, opts)
-      opts.servers = require("astrocore").list_insert_unique(opts.servers or {}, { "html", "cssls", "emmet_ls" })
+      opts.servers = require("astrocore").list_insert_unique(opts.servers or {}, { "html", "cssls" })
     end,
   },
   {
@@ -23,7 +23,7 @@ return {
     optional = true,
     opts = function(_, opts)
       opts.ensure_installed =
-        require("astrocore").list_insert_unique(opts.ensure_installed, { "html", "cssls", "emmet_ls" })
+        require("astrocore").list_insert_unique(opts.ensure_installed, { "html", "cssls" })
     end,
   },
   {
@@ -33,7 +33,6 @@ return {
       opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, {
         "html-lsp",
         "css-lsp",
-        "emmet-ls",
       })
     end,
   },


### PR DESCRIPTION
## Summary
- Add HTML/CSS language support with html, cssls, and emmet_ls LSP servers
- Configure treesitter parsers for html and css

Closes #127