### PR TITLE
feat(nvim): add JSON language support

### DIFF
--- a/programs/nvim/config/lua/plugins/lang/json.lua
+++ b/programs/nvim/config/lua/plugins/lang/json.lua
@@ -1,0 +1,50 @@
+-- JSON language support
+-- LSP: jsonls with schemastore
+
+return {
+  {
+    "b0o/schemastore.nvim",
+    lazy = true,
+  },
+  {
+    "AstroNvim/astrolsp",
+    optional = true,
+    opts = function(_, opts)
+      opts.servers = require("astrocore").list_insert_unique(opts.servers or {}, { "jsonls" })
+      opts.config = vim.tbl_deep_extend("force", opts.config or {}, {
+        jsonls = {
+          on_new_config = function(config)
+            if not config.settings.json then config.settings.json = {} end
+            config.settings.json.schemas = require("schemastore").json.schemas()
+            config.settings.json.validate = { enable = true }
+          end,
+        },
+      })
+    end,
+  },
+  {
+    "nvim-treesitter/nvim-treesitter",
+    optional = true,
+    opts = function(_, opts)
+      if opts.ensure_installed ~= "all" then
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "json", "jsonc" })
+      end
+    end,
+  },
+  {
+    "williamboman/mason-lspconfig.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "jsonls" })
+    end,
+  },
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, {
+        "json-lsp",
+      })
+    end,
+  },
+}

--- a/programs/nvim/config/lua/plugins/lang/json.lua
+++ b/programs/nvim/config/lua/plugins/lang/json.lua
@@ -1,5 +1,5 @@
 -- JSON language support
--- LSP: jsonls with schemastore
+-- LSP: jsonls with schemastore, Formatter: oxfmt
 
 return {
   {
@@ -10,7 +10,7 @@ return {
     "AstroNvim/astrolsp",
     optional = true,
     opts = function(_, opts)
-      opts.servers = require("astrocore").list_insert_unique(opts.servers or {}, { "jsonls" })
+      opts.servers = require("astrocore").list_insert_unique(opts.servers or {}, { "jsonls", "oxfmt" })
       opts.config = vim.tbl_deep_extend("force", opts.config or {}, {
         jsonls = {
           on_new_config = function(config)
@@ -35,7 +35,7 @@ return {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
     opts = function(_, opts)
-      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "jsonls" })
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "jsonls", "oxfmt" })
     end,
   },
   {
@@ -44,6 +44,7 @@ return {
     opts = function(_, opts)
       opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, {
         "json-lsp",
+        "oxfmt",
       })
     end,
   },


### PR DESCRIPTION
## Summary
- Add JSON language support with jsonls LSP and schemastore.nvim integration
- Configure treesitter parsers for json and jsonc
- Enable schema validation

Closes #129