### PR TITLE
feat(nvim): add YAML language support

### DIFF
--- a/programs/nvim/config/lua/plugins/lang/yaml.lua
+++ b/programs/nvim/config/lua/plugins/lang/yaml.lua
@@ -1,5 +1,5 @@
 -- YAML language support
--- LSP: yamlls with schemastore
+-- LSP: yamlls with schemastore, Formatter: oxfmt
 
 return {
   {
@@ -10,7 +10,7 @@ return {
     "AstroNvim/astrolsp",
     optional = true,
     opts = function(_, opts)
-      opts.servers = require("astrocore").list_insert_unique(opts.servers or {}, { "yamlls" })
+      opts.servers = require("astrocore").list_insert_unique(opts.servers or {}, { "yamlls", "oxfmt" })
       opts.config = vim.tbl_deep_extend("force", opts.config or {}, {
         yamlls = {
           on_new_config = function(config)
@@ -44,7 +44,7 @@ return {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
     opts = function(_, opts)
-      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "yamlls" })
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "yamlls", "oxfmt" })
     end,
   },
   {
@@ -53,6 +53,7 @@ return {
     opts = function(_, opts)
       opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, {
         "yaml-language-server",
+        "oxfmt",
       })
     end,
   },

--- a/programs/nvim/config/lua/plugins/lang/yaml.lua
+++ b/programs/nvim/config/lua/plugins/lang/yaml.lua
@@ -1,0 +1,59 @@
+-- YAML language support
+-- LSP: yamlls with schemastore
+
+return {
+  {
+    "b0o/schemastore.nvim",
+    lazy = true,
+  },
+  {
+    "AstroNvim/astrolsp",
+    optional = true,
+    opts = function(_, opts)
+      opts.servers = require("astrocore").list_insert_unique(opts.servers or {}, { "yamlls" })
+      opts.config = vim.tbl_deep_extend("force", opts.config or {}, {
+        yamlls = {
+          on_new_config = function(config)
+            if not config.settings.yaml then config.settings.yaml = {} end
+            config.settings.yaml.schemas =
+              vim.tbl_extend("force", config.settings.yaml.schemas or {}, require("schemastore").yaml.schemas())
+          end,
+          settings = {
+            yaml = {
+              validate = true,
+              schemaStore = {
+                enable = false, -- use schemastore.nvim instead
+                url = "",
+              },
+            },
+          },
+        },
+      })
+    end,
+  },
+  {
+    "nvim-treesitter/nvim-treesitter",
+    optional = true,
+    opts = function(_, opts)
+      if opts.ensure_installed ~= "all" then
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "yaml" })
+      end
+    end,
+  },
+  {
+    "williamboman/mason-lspconfig.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "yamlls" })
+    end,
+  },
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, {
+        "yaml-language-server",
+      })
+    end,
+  },
+}


### PR DESCRIPTION
## Summary
- Add YAML language support with yamlls LSP and schemastore.nvim integration
- Configure treesitter parser for yaml
- Disable built-in schemaStore in favor of schemastore.nvim

Closes #130