### PR TITLE
feat(nvim): add TOML language support

### DIFF
--- a/programs/nvim/config/lua/plugins/lang/toml.lua
+++ b/programs/nvim/config/lua/plugins/lang/toml.lua
@@ -1,0 +1,37 @@
+-- TOML language support
+-- LSP: taplo (includes formatting)
+
+return {
+  {
+    "AstroNvim/astrolsp",
+    optional = true,
+    opts = function(_, opts)
+      opts.servers = require("astrocore").list_insert_unique(opts.servers or {}, { "taplo" })
+    end,
+  },
+  {
+    "nvim-treesitter/nvim-treesitter",
+    optional = true,
+    opts = function(_, opts)
+      if opts.ensure_installed ~= "all" then
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "toml" })
+      end
+    end,
+  },
+  {
+    "williamboman/mason-lspconfig.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "taplo" })
+    end,
+  },
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, {
+        "taplo",
+      })
+    end,
+  },
+}

--- a/programs/nvim/config/lua/plugins/lang/toml.lua
+++ b/programs/nvim/config/lua/plugins/lang/toml.lua
@@ -1,5 +1,5 @@
 -- TOML language support
--- LSP: taplo (includes formatting)
+-- LSP: taplo, Formatting: oxfmt
 
 return {
   {
@@ -33,5 +33,14 @@ return {
         "taplo",
       })
     end,
+  },
+  {
+    "stevearc/conform.nvim",
+    optional = true,
+    opts = {
+      formatters_by_ft = {
+        toml = { "oxfmt" },
+      },
+    },
   },
 }

--- a/programs/nvim/config/lua/plugins/lang/toml.lua
+++ b/programs/nvim/config/lua/plugins/lang/toml.lua
@@ -1,12 +1,12 @@
 -- TOML language support
--- LSP: taplo, Formatter: oxfmt
+-- LSP: taplo (includes formatting)
 
 return {
   {
     "AstroNvim/astrolsp",
     optional = true,
     opts = function(_, opts)
-      opts.servers = require("astrocore").list_insert_unique(opts.servers or {}, { "taplo", "oxfmt" })
+      opts.servers = require("astrocore").list_insert_unique(opts.servers or {}, { "taplo" })
     end,
   },
   {
@@ -22,7 +22,7 @@ return {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
     opts = function(_, opts)
-      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "taplo", "oxfmt" })
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "taplo" })
     end,
   },
   {
@@ -31,7 +31,6 @@ return {
     opts = function(_, opts)
       opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, {
         "taplo",
-        "oxfmt",
       })
     end,
   },

--- a/programs/nvim/config/lua/plugins/lang/toml.lua
+++ b/programs/nvim/config/lua/plugins/lang/toml.lua
@@ -1,12 +1,12 @@
 -- TOML language support
--- LSP: taplo (includes formatting)
+-- LSP: taplo, Formatter: oxfmt
 
 return {
   {
     "AstroNvim/astrolsp",
     optional = true,
     opts = function(_, opts)
-      opts.servers = require("astrocore").list_insert_unique(opts.servers or {}, { "taplo" })
+      opts.servers = require("astrocore").list_insert_unique(opts.servers or {}, { "taplo", "oxfmt" })
     end,
   },
   {
@@ -22,7 +22,7 @@ return {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
     opts = function(_, opts)
-      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "taplo" })
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "taplo", "oxfmt" })
     end,
   },
   {
@@ -31,6 +31,7 @@ return {
     opts = function(_, opts)
       opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, {
         "taplo",
+        "oxfmt",
       })
     end,
   },


### PR DESCRIPTION
## Summary
- Add TOML language support with taplo LSP (includes built-in formatting)
- Configure treesitter parser for toml

Closes #131