### PR TITLE
feat(nvim): add Markdown language support

### DIFF
--- a/programs/nvim/config/lua/plugins/lang/markdown.lua
+++ b/programs/nvim/config/lua/plugins/lang/markdown.lua
@@ -1,12 +1,12 @@
 -- Markdown language support
--- LSP: marksman, Formatter: oxfmt
+-- LSP: marksman
 
 return {
   {
     "AstroNvim/astrolsp",
     optional = true,
     opts = function(_, opts)
-      opts.servers = require("astrocore").list_insert_unique(opts.servers or {}, { "marksman", "oxfmt" })
+      opts.servers = require("astrocore").list_insert_unique(opts.servers or {}, { "marksman" })
     end,
   },
   {
@@ -23,7 +23,7 @@ return {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
     opts = function(_, opts)
-      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "marksman", "oxfmt" })
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "marksman" })
     end,
   },
   {
@@ -32,7 +32,6 @@ return {
     opts = function(_, opts)
       opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, {
         "marksman",
-        "oxfmt",
       })
     end,
   },

--- a/programs/nvim/config/lua/plugins/lang/markdown.lua
+++ b/programs/nvim/config/lua/plugins/lang/markdown.lua
@@ -1,5 +1,5 @@
 -- Markdown language support
--- LSP: marksman
+-- LSP: marksman, Formatting: oxfmt
 
 return {
   {
@@ -34,5 +34,14 @@ return {
         "marksman",
       })
     end,
+  },
+  {
+    "stevearc/conform.nvim",
+    optional = true,
+    opts = {
+      formatters_by_ft = {
+        markdown = { "oxfmt" },
+      },
+    },
   },
 }

--- a/programs/nvim/config/lua/plugins/lang/markdown.lua
+++ b/programs/nvim/config/lua/plugins/lang/markdown.lua
@@ -1,12 +1,12 @@
 -- Markdown language support
--- LSP: marksman
+-- LSP: marksman, Formatter: oxfmt
 
 return {
   {
     "AstroNvim/astrolsp",
     optional = true,
     opts = function(_, opts)
-      opts.servers = require("astrocore").list_insert_unique(opts.servers or {}, { "marksman" })
+      opts.servers = require("astrocore").list_insert_unique(opts.servers or {}, { "marksman", "oxfmt" })
     end,
   },
   {
@@ -23,7 +23,7 @@ return {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
     opts = function(_, opts)
-      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "marksman" })
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "marksman", "oxfmt" })
     end,
   },
   {
@@ -32,6 +32,7 @@ return {
     opts = function(_, opts)
       opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, {
         "marksman",
+        "oxfmt",
       })
     end,
   },

--- a/programs/nvim/config/lua/plugins/lang/markdown.lua
+++ b/programs/nvim/config/lua/plugins/lang/markdown.lua
@@ -1,0 +1,38 @@
+-- Markdown language support
+-- LSP: marksman
+
+return {
+  {
+    "AstroNvim/astrolsp",
+    optional = true,
+    opts = function(_, opts)
+      opts.servers = require("astrocore").list_insert_unique(opts.servers or {}, { "marksman" })
+    end,
+  },
+  {
+    "nvim-treesitter/nvim-treesitter",
+    optional = true,
+    opts = function(_, opts)
+      if opts.ensure_installed ~= "all" then
+        opts.ensure_installed =
+          require("astrocore").list_insert_unique(opts.ensure_installed, { "markdown", "markdown_inline" })
+      end
+    end,
+  },
+  {
+    "williamboman/mason-lspconfig.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "marksman" })
+    end,
+  },
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, {
+        "marksman",
+      })
+    end,
+  },
+}


### PR DESCRIPTION
## Summary
- Add Markdown language support with marksman LSP
- Configure treesitter parsers for markdown and markdown_inline

Closes #132