### PR TITLE
feat(nvim): add Docker language support

### DIFF
--- a/programs/nvim/config/lua/plugins/lang/docker.lua
+++ b/programs/nvim/config/lua/plugins/lang/docker.lua
@@ -1,0 +1,55 @@
+-- Docker language support
+-- LSP: dockerls, docker_compose_language_service
+-- Linter: hadolint
+
+return {
+  {
+    "AstroNvim/astrolsp",
+    optional = true,
+    opts = function(_, opts)
+      opts.servers = require("astrocore").list_insert_unique(
+        opts.servers or {},
+        { "dockerls", "docker_compose_language_service" }
+      )
+    end,
+  },
+  {
+    "nvim-treesitter/nvim-treesitter",
+    optional = true,
+    opts = function(_, opts)
+      if opts.ensure_installed ~= "all" then
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "dockerfile" })
+      end
+    end,
+  },
+  {
+    "williamboman/mason-lspconfig.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(
+        opts.ensure_installed,
+        { "dockerls", "docker_compose_language_service" }
+      )
+    end,
+  },
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, {
+        "dockerfile-language-server",
+        "docker-compose-language-service",
+        "hadolint",
+      })
+    end,
+  },
+  {
+    "mfussenegger/nvim-lint",
+    optional = true,
+    opts = {
+      linters_by_ft = {
+        dockerfile = { "hadolint" },
+      },
+    },
+  },
+}


### PR DESCRIPTION
## Summary
- Add Docker language support with dockerls and docker_compose_language_service LSP
- Configure treesitter parser for dockerfile
- Add hadolint linter via nvim-lint

Closes #134