### PR TITLE
feat(nvim): add Protocol Buffers language support

### DIFF
--- a/programs/nvim/config/lua/plugins/lang/proto.lua
+++ b/programs/nvim/config/lua/plugins/lang/proto.lua
@@ -1,0 +1,56 @@
+-- Protocol Buffers language support
+-- LSP: buf_ls
+-- Formatter: buf, Linter: buf_lint
+
+return {
+  {
+    "AstroNvim/astrolsp",
+    optional = true,
+    opts = function(_, opts)
+      opts.servers = require("astrocore").list_insert_unique(opts.servers or {}, { "buf_ls" })
+    end,
+  },
+  {
+    "nvim-treesitter/nvim-treesitter",
+    optional = true,
+    opts = function(_, opts)
+      if opts.ensure_installed ~= "all" then
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "proto" })
+      end
+    end,
+  },
+  {
+    "williamboman/mason-lspconfig.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "buf_ls" })
+    end,
+  },
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, {
+        "buf",
+      })
+    end,
+  },
+  {
+    "stevearc/conform.nvim",
+    optional = true,
+    opts = {
+      formatters_by_ft = {
+        proto = { "buf" },
+      },
+    },
+  },
+  {
+    "mfussenegger/nvim-lint",
+    optional = true,
+    opts = {
+      linters_by_ft = {
+        proto = { "buf_lint" },
+      },
+    },
+  },
+}


### PR DESCRIPTION
## Summary
- Add Protocol Buffers language support with buf_ls LSP
- Configure treesitter parser for proto
- Add buf formatter and buf_lint linter

Closes #136