### PR TITLE
feat(nvim): add Rego language support

### DIFF
--- a/programs/nvim/config/lua/plugins/lang/rego.lua
+++ b/programs/nvim/config/lua/plugins/lang/rego.lua
@@ -1,0 +1,46 @@
+-- Rego language support
+-- LSP: regols
+
+return {
+  {
+    "AstroNvim/astrolsp",
+    optional = true,
+    opts = function(_, opts)
+      opts.servers = require("astrocore").list_insert_unique(opts.servers or {}, { "regols" })
+    end,
+  },
+  {
+    "nvim-treesitter/nvim-treesitter",
+    optional = true,
+    opts = function(_, opts)
+      if opts.ensure_installed ~= "all" then
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "rego" })
+      end
+    end,
+  },
+  {
+    "williamboman/mason-lspconfig.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "regols" })
+    end,
+  },
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, {
+        "regols",
+      })
+    end,
+  },
+  {
+    "mfussenegger/nvim-lint",
+    optional = true,
+    opts = {
+      linters_by_ft = {
+        rego = { "opa_check" },
+      },
+    },
+  },
+}


### PR DESCRIPTION
## Summary
- Add Rego language support with regols LSP
- Configure treesitter parser for rego
- Add opa_check linter via nvim-lint

Closes #138