### PR TITLE
feat(nvim): add Ruby language support

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -42,6 +42,9 @@
       # AI tools
       chikuwa
 
+      # Build tools
+      gcc
+
       # CLI tools
       ripgrep
       fzf

--- a/programs/nvim/config/lua/plugins/lang/ruby.lua
+++ b/programs/nvim/config/lua/plugins/lang/ruby.lua
@@ -1,0 +1,37 @@
+-- Ruby language support
+-- LSP: ruby-lsp (Shopify)
+
+return {
+  {
+    "AstroNvim/astrolsp",
+    optional = true,
+    opts = function(_, opts)
+      opts.servers = require("astrocore").list_insert_unique(opts.servers or {}, { "ruby_lsp" })
+    end,
+  },
+  {
+    "nvim-treesitter/nvim-treesitter",
+    optional = true,
+    opts = function(_, opts)
+      if opts.ensure_installed ~= "all" then
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "ruby" })
+      end
+    end,
+  },
+  {
+    "williamboman/mason-lspconfig.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "ruby_lsp" })
+    end,
+  },
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, {
+        "ruby-lsp",
+      })
+    end,
+  },
+}


### PR DESCRIPTION
## Summary
- Add Ruby language support with ruby-lsp (Shopify)
- Configure treesitter parser for Ruby
- Add gcc to home.nix for building native gem extensions (rbs)

Closes #124