### PR TITLE
feat(nix): add gcc for building native gem extensions

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -42,6 +42,9 @@
       # AI tools
       chikuwa
 
+      # Build tools
+      gcc
+
       # CLI tools
       ripgrep
       fzf


### PR DESCRIPTION
## Summary
- Add gcc to home packages for building native gem extensions (e.g. rbs gem required by ruby-lsp)

## Test plan
- [ ] Run hms to apply
- [ ] Verify Mason can install ruby-lsp without build errors