### PR TITLE
fix(nvim): use check.command instead of deprecated checkOnSave for rust_analyzer

### DIFF
--- a/programs/nvim/config/lua/plugins/lang/rust.lua
+++ b/programs/nvim/config/lua/plugins/lang/rust.lua
@@ -11,7 +11,7 @@ return {
         rust_analyzer = {
           settings = {
             ["rust-analyzer"] = {
-              checkOnSave = {
+              check = {
                 command = "clippy",
               },
               inlayHints = {


### PR DESCRIPTION
## Summary
- Fix rust_analyzer config: checkOnSave is now a boolean, use check.command instead

## Test plan
- [ ] Open a Rust file and verify no LSP warning about invalid config