### PR TITLE
feat(nvim): centralize oxfmt config using vim.lsp.config

### DIFF
--- a/programs/nvim/config/lua/plugins/lang/oxfmt.lua
+++ b/programs/nvim/config/lua/plugins/lang/oxfmt.lua
@@ -1,0 +1,38 @@
+-- Oxfmt formatter (LSP-based)
+-- Supports: JS, TS, JSON, YAML, HTML, CSS, SCSS, Markdown, MDX, TOML, GraphQL, Vue
+
+vim.lsp.config("oxfmt", {
+  cmd = { "oxfmt", "--lsp" },
+  filetypes = {
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact",
+    "json",
+    "jsonc",
+    "yaml",
+    "html",
+    "css",
+    "scss",
+    "less",
+    "markdown",
+    "mdx",
+    "toml",
+    "graphql",
+    "vue",
+  },
+  root_markers = { ".oxfmtrc.json", "package.json", ".git" },
+})
+vim.lsp.enable("oxfmt")
+
+return {
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, {
+        "oxfmt",
+      })
+    end,
+  },
+}

--- a/programs/nvim/config/lua/plugins/lang/typescript.lua
+++ b/programs/nvim/config/lua/plugins/lang/typescript.lua
@@ -1,5 +1,4 @@
 -- TypeScript/JavaScript language support
--- Formatting: oxfmt (LSP)
 -- Linting: oxlint (LSP)
 
 return {
@@ -7,7 +6,7 @@ return {
     "AstroNvim/astrolsp",
     optional = true,
     opts = function(_, opts)
-      opts.servers = require("astrocore").list_insert_unique(opts.servers or {}, { "ts_ls", "oxfmt", "oxlint" })
+      opts.servers = require("astrocore").list_insert_unique(opts.servers or {}, { "ts_ls", "oxlint" })
       opts.config = vim.tbl_deep_extend("force", opts.config or {}, {
         ts_ls = {
           settings = {
@@ -51,7 +50,7 @@ return {
     optional = true,
     opts = function(_, opts)
       opts.ensure_installed =
-        require("astrocore").list_insert_unique(opts.ensure_installed, { "ts_ls", "oxfmt", "oxlint" })
+        require("astrocore").list_insert_unique(opts.ensure_installed, { "ts_ls", "oxlint" })
     end,
   },
   {
@@ -60,7 +59,6 @@ return {
     opts = function(_, opts)
       opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, {
         "typescript-language-server",
-        "oxfmt",
         "oxlint",
       })
     end,


### PR DESCRIPTION
## Summary
- Add centralized oxfmt configuration using Neovim 0.11's vim.lsp.config() and vim.lsp.enable()
- Remove oxfmt from TypeScript lang pack's astrolsp/mason-lspconfig registration (oxfmt config was only in lspconfig's new lsp/ directory, not supported by astrolsp)
- oxfmt is now managed independently and applies to all supported filetypes (JS, TS, JSON, YAML, HTML, CSS, Markdown, MDX, TOML, etc.)

## Test plan
- [ ] Open a TypeScript file and verify oxfmt formatter works
- [ ] Open a JSON file and verify oxfmt formatter works
- [ ] Verify no more lspconfig 'oxfmt not found' errors