### PR TITLE
fix(nvim): remove oxfmt from astrolsp registration in lang packs

### DIFF
--- a/programs/nvim/config/lua/plugins/lang/html-css.lua
+++ b/programs/nvim/config/lua/plugins/lang/html-css.lua
@@ -1,12 +1,12 @@
 -- HTML/CSS language support
--- LSP: html, cssls, Formatter: oxfmt
+-- LSP: html, cssls
 
 return {
   {
     "AstroNvim/astrolsp",
     optional = true,
     opts = function(_, opts)
-      opts.servers = require("astrocore").list_insert_unique(opts.servers or {}, { "html", "cssls", "oxfmt" })
+      opts.servers = require("astrocore").list_insert_unique(opts.servers or {}, { "html", "cssls" })
     end,
   },
   {
@@ -23,7 +23,7 @@ return {
     optional = true,
     opts = function(_, opts)
       opts.ensure_installed =
-        require("astrocore").list_insert_unique(opts.ensure_installed, { "html", "cssls", "oxfmt" })
+        require("astrocore").list_insert_unique(opts.ensure_installed, { "html", "cssls" })
     end,
   },
   {
@@ -33,7 +33,6 @@ return {
       opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, {
         "html-lsp",
         "css-lsp",
-        "oxfmt",
       })
     end,
   },

--- a/programs/nvim/config/lua/plugins/lang/json.lua
+++ b/programs/nvim/config/lua/plugins/lang/json.lua
@@ -1,5 +1,5 @@
 -- JSON language support
--- LSP: jsonls with schemastore, Formatter: oxfmt
+-- LSP: jsonls with schemastore
 
 return {
   {
@@ -10,7 +10,7 @@ return {
     "AstroNvim/astrolsp",
     optional = true,
     opts = function(_, opts)
-      opts.servers = require("astrocore").list_insert_unique(opts.servers or {}, { "jsonls", "oxfmt" })
+      opts.servers = require("astrocore").list_insert_unique(opts.servers or {}, { "jsonls" })
       opts.config = vim.tbl_deep_extend("force", opts.config or {}, {
         jsonls = {
           on_new_config = function(config)
@@ -35,7 +35,7 @@ return {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
     opts = function(_, opts)
-      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "jsonls", "oxfmt" })
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "jsonls" })
     end,
   },
   {
@@ -44,7 +44,6 @@ return {
     opts = function(_, opts)
       opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, {
         "json-lsp",
-        "oxfmt",
       })
     end,
   },

--- a/programs/nvim/config/lua/plugins/lang/yaml.lua
+++ b/programs/nvim/config/lua/plugins/lang/yaml.lua
@@ -1,5 +1,5 @@
 -- YAML language support
--- LSP: yamlls with schemastore, Formatter: oxfmt
+-- LSP: yamlls with schemastore
 
 return {
   {
@@ -10,7 +10,7 @@ return {
     "AstroNvim/astrolsp",
     optional = true,
     opts = function(_, opts)
-      opts.servers = require("astrocore").list_insert_unique(opts.servers or {}, { "yamlls", "oxfmt" })
+      opts.servers = require("astrocore").list_insert_unique(opts.servers or {}, { "yamlls" })
       opts.config = vim.tbl_deep_extend("force", opts.config or {}, {
         yamlls = {
           on_new_config = function(config)
@@ -44,7 +44,7 @@ return {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
     opts = function(_, opts)
-      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "yamlls", "oxfmt" })
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "yamlls" })
     end,
   },
   {
@@ -53,7 +53,6 @@ return {
     opts = function(_, opts)
       opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, {
         "yaml-language-server",
-        "oxfmt",
       })
     end,
   },


### PR DESCRIPTION
## Summary
- Remove oxfmt from astrolsp/mason-lspconfig registration in JSON, YAML, HTML/CSS lang packs
- oxfmt is now centrally managed via oxfmt.lua using vim.lsp.config() (#266)

## Test plan
- [ ] Verify no more lspconfig 'oxfmt not found' errors on startup