### PR TITLE
refactor(nvim): switch oxfmt from LSP to conform.nvim

### DIFF
--- a/programs/nvim/config/lua/plugins/lang/html-css.lua
+++ b/programs/nvim/config/lua/plugins/lang/html-css.lua
@@ -1,5 +1,5 @@
 -- HTML/CSS language support
--- LSP: html, cssls
+-- LSP: html, cssls, Formatting: oxfmt
 
 return {
   {
@@ -35,5 +35,17 @@ return {
         "css-lsp",
       })
     end,
+  },
+  {
+    "stevearc/conform.nvim",
+    optional = true,
+    opts = {
+      formatters_by_ft = {
+        html = { "oxfmt" },
+        css = { "oxfmt" },
+        scss = { "oxfmt" },
+        less = { "oxfmt" },
+      },
+    },
   },
 }

--- a/programs/nvim/config/lua/plugins/lang/json.lua
+++ b/programs/nvim/config/lua/plugins/lang/json.lua
@@ -1,5 +1,5 @@
 -- JSON language support
--- LSP: jsonls with schemastore
+-- LSP: jsonls with schemastore, Formatting: oxfmt
 
 return {
   {
@@ -46,5 +46,15 @@ return {
         "json-lsp",
       })
     end,
+  },
+  {
+    "stevearc/conform.nvim",
+    optional = true,
+    opts = {
+      formatters_by_ft = {
+        json = { "oxfmt" },
+        jsonc = { "oxfmt" },
+      },
+    },
   },
 }

--- a/programs/nvim/config/lua/plugins/lang/oxfmt.lua
+++ b/programs/nvim/config/lua/plugins/lang/oxfmt.lua
@@ -1,5 +1,6 @@
 -- Oxfmt formatter (via conform.nvim)
--- Supports: JS, TS, JSON, YAML, HTML, CSS, SCSS, Markdown, MDX, TOML, GraphQL, Vue
+-- Mason install + filetypes without dedicated lang files
+-- Per-language oxfmt formatters_by_ft are configured in each language file
 
 return {
   {
@@ -7,20 +8,6 @@ return {
     optional = true,
     opts = {
       formatters_by_ft = {
-        javascript = { "oxfmt" },
-        javascriptreact = { "oxfmt" },
-        typescript = { "oxfmt" },
-        typescriptreact = { "oxfmt" },
-        json = { "oxfmt" },
-        jsonc = { "oxfmt" },
-        yaml = { "oxfmt" },
-        html = { "oxfmt" },
-        css = { "oxfmt" },
-        scss = { "oxfmt" },
-        less = { "oxfmt" },
-        markdown = { "oxfmt" },
-        mdx = { "oxfmt" },
-        toml = { "oxfmt" },
         graphql = { "oxfmt" },
         vue = { "oxfmt" },
       },

--- a/programs/nvim/config/lua/plugins/lang/oxfmt.lua
+++ b/programs/nvim/config/lua/plugins/lang/oxfmt.lua
@@ -1,31 +1,31 @@
--- Oxfmt formatter (LSP-based)
+-- Oxfmt formatter (via conform.nvim)
 -- Supports: JS, TS, JSON, YAML, HTML, CSS, SCSS, Markdown, MDX, TOML, GraphQL, Vue
 
-vim.lsp.config("oxfmt", {
-  cmd = { "oxfmt", "--lsp" },
-  filetypes = {
-    "javascript",
-    "javascriptreact",
-    "typescript",
-    "typescriptreact",
-    "json",
-    "jsonc",
-    "yaml",
-    "html",
-    "css",
-    "scss",
-    "less",
-    "markdown",
-    "mdx",
-    "toml",
-    "graphql",
-    "vue",
-  },
-  root_markers = { ".oxfmtrc.json", "package.json", ".git" },
-})
-vim.lsp.enable("oxfmt")
-
 return {
+  {
+    "stevearc/conform.nvim",
+    optional = true,
+    opts = {
+      formatters_by_ft = {
+        javascript = { "oxfmt" },
+        javascriptreact = { "oxfmt" },
+        typescript = { "oxfmt" },
+        typescriptreact = { "oxfmt" },
+        json = { "oxfmt" },
+        jsonc = { "oxfmt" },
+        yaml = { "oxfmt" },
+        html = { "oxfmt" },
+        css = { "oxfmt" },
+        scss = { "oxfmt" },
+        less = { "oxfmt" },
+        markdown = { "oxfmt" },
+        mdx = { "oxfmt" },
+        toml = { "oxfmt" },
+        graphql = { "oxfmt" },
+        vue = { "oxfmt" },
+      },
+    },
+  },
   {
     "WhoIsSethDaniel/mason-tool-installer.nvim",
     optional = true,

--- a/programs/nvim/config/lua/plugins/lang/typescript.lua
+++ b/programs/nvim/config/lua/plugins/lang/typescript.lua
@@ -1,5 +1,5 @@
 -- TypeScript/JavaScript language support
--- Linting: oxlint (LSP)
+-- Formatting: oxfmt, Linting: oxlint (LSP)
 
 return {
   {
@@ -62,6 +62,18 @@ return {
         "oxlint",
       })
     end,
+  },
+  {
+    "stevearc/conform.nvim",
+    optional = true,
+    opts = {
+      formatters_by_ft = {
+        javascript = { "oxfmt" },
+        javascriptreact = { "oxfmt" },
+        typescript = { "oxfmt" },
+        typescriptreact = { "oxfmt" },
+      },
+    },
   },
   {
     "echasnovski/mini.icons",

--- a/programs/nvim/config/lua/plugins/lang/yaml.lua
+++ b/programs/nvim/config/lua/plugins/lang/yaml.lua
@@ -1,5 +1,5 @@
 -- YAML language support
--- LSP: yamlls with schemastore
+-- LSP: yamlls with schemastore, Formatting: oxfmt
 
 return {
   {
@@ -55,5 +55,14 @@ return {
         "yaml-language-server",
       })
     end,
+  },
+  {
+    "stevearc/conform.nvim",
+    optional = true,
+    opts = {
+      formatters_by_ft = {
+        yaml = { "oxfmt" },
+      },
+    },
   },
 }


### PR DESCRIPTION
## Summary
- Switch oxfmt from LSP-based approach (vim.lsp.config + vim.lsp.enable) to conform.nvim
- Registers oxfmt as a conform.nvim formatter for all supported filetypes (JS, TS, JSON, YAML, HTML, CSS, SCSS, Markdown, MDX, TOML, GraphQL, Vue)
- Keeps mason-tool-installer for oxfmt binary installation

## Test plan
- [ ] Open a JS/TS file and verify formatting works with oxfmt
- [ ] Open a JSON/YAML file and verify formatting works
- [ ] Verify no more lspconfig oxfmt errors on startup