### PR TITLE
feat(zsh): use clip.exe for pbcopy on WSL

### DIFF
--- a/programs/zsh/default.nix
+++ b/programs/zsh/default.nix
@@ -70,8 +70,8 @@ in
       mv = "mv -i";
       mkdir = "mkdir -p";
 
-      # Linux clipboard
-      pbcopy = "xsel --clipboard --input";
+      # Clipboard / open
+      pbcopy = if isWSL then "clip.exe" else "xsel --clipboard --input";
       open = "xdg-open";
 
       # General commands


### PR DESCRIPTION
## Summary
- Make the `pbcopy` alias conditional on `isWSL`: use `clip.exe` on WSL, `xsel --clipboard --input` on native Linux

## Test plan
- [ ] Run `hms` to apply the configuration
- [ ] Run `echo test | pbcopy` on WSL and verify clipboard content

Closes #219