### PR TITLE
feat(claude): add update-claude-tools skill

### DIFF
--- a/.claude/skills/update-claude-tools/SKILL.md
+++ b/.claude/skills/update-claude-tools/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: update-claude-tools
+description: >
+  Update @nownabe/claude-tools and @nownabe/claude-hooks documentation in the dotfiles repository
+  to match the latest commands and hooks from the source repository. Use when the user asks to
+  update, sync, or refresh claude-tools or claude-hooks documentation (e.g., "update claude-tools",
+  "sync claude-tools docs", "@nownabe/claude-tools を最新化して").
+---
+
+# Update Claude Tools
+
+Update `programs/claude/CLAUDE.md` in the dotfiles repo to reflect the latest commands and hooks
+from the `nownabe/claude` source repository.
+
+## Source
+
+Read `README.md` from `/home/nownabe/src/github.com/nownabe/claude`.
+
+It contains two tables:
+- **Tools** table — `Command | Description` for `@nownabe/claude-tools`
+- **Hooks** table — `Hook | Description` for `@nownabe/claude-hooks`
+
+For detailed usage (arguments, options) of each command, read
+`docs/claude-tools/gh/<command>.md` from the same repo.
+
+## Target
+
+`programs/claude/CLAUDE.md` in this repo (deployed as `~/.claude/CLAUDE.md` via Home Manager).
+
+## Workflow
+
+1. **Read source**: Read `/home/nownabe/src/github.com/nownabe/claude/README.md` to get the
+   current command and hook lists.
+
+2. **Read command docs**: For each command, read `docs/claude-tools/gh/<command>.md` from the
+   source repo to extract the usage pattern (arguments and options).
+
+3. **Update CLAUDE.md**: Update the `## @nownabe/claude-tools` section in `programs/claude/CLAUDE.md`.
+   Preserve the existing format:
+
+   ```markdown
+   ## @nownabe/claude-tools
+
+   `@nownabe/claude-tools` provides GitHub-related CLI utilities. Run via `bunx @nownabe/claude-tools <command>`.
+
+   Available commands:
+
+   - `gh <command> <args> [options]` — <description>
+   ...
+
+   All commands accept `--repo <owner/repo>` to target a specific repository (defaults to current repo).
+   ```
+
+4. **Commit and create PR**: Follow the repository's PR rules (Conventional Commits, labels, etc.).
+   Use type `chore` and scope `claude`. Example: `chore(claude): update claude-tools documentation`.

--- a/.claude/skills/update-claude-tools/SKILL.md
+++ b/.claude/skills/update-claude-tools/SKILL.md
@@ -9,47 +9,58 @@ description: >
 
 # Update Claude Tools
 
-Update `programs/claude/CLAUDE.md` in the dotfiles repo to reflect the latest commands and hooks
-from the `nownabe/claude` source repository.
-
-## Source
-
-Read `README.md` from `/home/nownabe/src/github.com/nownabe/claude`.
-
-It contains two tables:
-- **Tools** table — `Command | Description` for `@nownabe/claude-tools`
-- **Hooks** table — `Hook | Description` for `@nownabe/claude-hooks`
-
-For detailed usage (arguments, options) of each command, read
-`docs/claude-tools/gh/<command>.md` from the same repo.
-
-## Target
-
-`programs/claude/CLAUDE.md` in this repo (deployed as `~/.claude/CLAUDE.md` via Home Manager).
+Update `programs/claude/CLAUDE.md` in this repo to reflect the latest commands and hooks from the
+`nownabe/claude` source repository. This file is deployed as `~/.claude/CLAUDE.md` via Home Manager.
 
 ## Workflow
 
-1. **Read source**: Read `/home/nownabe/src/github.com/nownabe/claude/README.md` to get the
-   current command and hook lists.
+### 1. Read source
 
-2. **Read command docs**: For each command, read `docs/claude-tools/gh/<command>.md` from the
-   source repo to extract the usage pattern (arguments and options).
+Read `/home/nownabe/src/github.com/nownabe/claude/README.md`. It has:
 
-3. **Update CLAUDE.md**: Update the `## @nownabe/claude-tools` section in `programs/claude/CLAUDE.md`.
-   Preserve the existing format:
+- **Tools** table — command names and descriptions for `@nownabe/claude-tools`
+- **Hooks** table — hook names and descriptions for `@nownabe/claude-hooks`
 
-   ```markdown
-   ## @nownabe/claude-tools
+### 2. Read command docs
 
-   `@nownabe/claude-tools` provides GitHub-related CLI utilities. Run via `bunx @nownabe/claude-tools <command>`.
+For each command in the Tools table, read its doc file at
+`/home/nownabe/src/github.com/nownabe/claude/docs/claude-tools/gh/<command>.md`.
 
-   Available commands:
+Extract the usage line from the `## Usage` code block. For example:
 
-   - `gh <command> <args> [options]` — <description>
-   ...
+```
+claude-tools gh get-release [--tag <tag>] [--jq <expr>] [--repo <owner/repo>]
+```
 
-   All commands accept `--repo <owner/repo>` to target a specific repository (defaults to current repo).
-   ```
+Transform it for CLAUDE.md:
 
-4. **Commit and create PR**: Follow the repository's PR rules (Conventional Commits, labels, etc.).
-   Use type `chore` and scope `claude`. Example: `chore(claude): update claude-tools documentation`.
+- Strip the `claude-tools` prefix (keep `gh <command> ...`)
+- Remove `[--repo <owner/repo>]` (documented separately as a shared option)
+- Combine with the description from the README table
+
+Result: `` `gh get-release [--tag <tag>] [--jq <expr>]` — get release info (latest by default) ``
+
+### 3. Update CLAUDE.md
+
+Update the `## @nownabe/claude-tools` section in `programs/claude/CLAUDE.md`, preserving this format:
+
+```markdown
+## @nownabe/claude-tools
+
+`@nownabe/claude-tools` provides GitHub-related CLI utilities. Run via `bunx @nownabe/claude-tools <command>`.
+
+Available commands:
+
+- `gh <command> <args> [options]` — <description>
+...
+
+All commands accept `--repo <owner/repo>` to target a specific repository (defaults to current repo).
+```
+
+Add, remove, or update commands as needed to match the source. Keep descriptions concise
+(lowercase, no trailing period).
+
+### 4. Commit and create PR
+
+Follow the repository's PR rules. Use type `chore` and scope `claude`.
+Example: `chore(claude): update claude-tools documentation`.

--- a/.claude/skills/update-claude-tools/SKILL.md
+++ b/.claude/skills/update-claude-tools/SKILL.md
@@ -29,7 +29,7 @@ For each command in the Tools table, read its doc file at
 Extract the usage line from the `## Usage` code block. For example:
 
 ```
-claude-tools gh get-release [--tag <tag>] [--jq <expr>] [--repo <owner/repo>]
+claude-tools gh get-job-logs <job_id> [--repo <owner/repo>] [--no-strip-timestamps]
 ```
 
 Transform it for CLAUDE.md:
@@ -38,7 +38,7 @@ Transform it for CLAUDE.md:
 - Remove `[--repo <owner/repo>]` (documented separately as a shared option)
 - Combine with the description from the README table
 
-Result: `` `gh get-release [--tag <tag>] [--jq <expr>]` — get release info (latest by default) ``
+Result: `` `gh get-job-logs <job_id> [--no-strip-timestamps]` — get logs for a specific job ``
 
 ### 3. Update CLAUDE.md
 

--- a/.claude/skills/update-claude-tools/SKILL.md
+++ b/.claude/skills/update-claude-tools/SKILL.md
@@ -16,15 +16,17 @@ Update `programs/claude/CLAUDE.md` in this repo to reflect the latest commands a
 
 ### 1. Read source
 
-Read `/home/nownabe/src/github.com/nownabe/claude/README.md`. It has:
+Fetch `README.md` from GitHub using `bunx @nownabe/claude-tools gh get-repo-content README.md --repo nownabe/claude`.
+
+It has:
 
 - **Tools** table — command names and descriptions for `@nownabe/claude-tools`
 - **Hooks** table — hook names and descriptions for `@nownabe/claude-hooks`
 
 ### 2. Read command docs
 
-For each command in the Tools table, read its doc file at
-`/home/nownabe/src/github.com/nownabe/claude/docs/claude-tools/gh/<command>.md`.
+For each command in the Tools table, fetch its doc file from GitHub using
+`bunx @nownabe/claude-tools gh get-repo-content docs/claude-tools/gh/<command>.md --repo nownabe/claude`.
 
 Extract the usage line from the `## Usage` code block. For example:
 


### PR DESCRIPTION
## Summary
- Add a project-local skill to update @nownabe/claude-tools and @nownabe/claude-hooks documentation in CLAUDE.md
- The skill reads command/hook lists from the nownabe/claude repository README.md and updates programs/claude/CLAUDE.md accordingly

## Test plan
- [ ] Verify the skill triggers when asking to update claude-tools
- [ ] Run the skill and confirm CLAUDE.md is updated correctly