### PR TITLE
chore(claude): update claude-tools documentation

### DIFF
--- a/programs/claude/CLAUDE.md
+++ b/programs/claude/CLAUDE.md
@@ -10,10 +10,11 @@
 
 Available commands:
 
-- `gh add-sub-issues <parent> <sub>...` — add sub-issues to a parent issue
+- `gh add-sub-issues <parent_issue_number> <sub_issue_number>...` — add sub-issues to a parent issue
 - `gh get-actions-run <run_id>` — get GitHub Actions workflow run info
 - `gh get-job-logs <job_id> [--no-strip-timestamps]` — get logs for a specific job
-- `gh get-release [--tag <tag>] [--jq <expr>]` — get release info (latest by default)
+- `gh get-release [--tag <tag>]` — get release info (latest by default)
+- `gh get-repo-content <path> [--ref <ref>] [--raw]` — get file content from a GitHub repository
 - `gh list-run-jobs <run_id>` — list jobs for a workflow run
 - `gh list-sub-issues <issue_number>` — list sub-issues of an issue
 - `gh resolve-tag-sha <owner/repo> <tag>` — resolve a tag to its commit SHA (useful for pinning GitHub Actions)


### PR DESCRIPTION
## Summary
- Add new `gh get-repo-content` command documentation
- Update `gh add-sub-issues` argument names to match source docs
- Remove non-existent `--jq` option from `gh get-release`

## Test plan
- [ ] Verify `hms` applies successfully
- [ ] Confirm CLAUDE.md commands match source repository