### PR TITLE
fix(nvim): remove empty on_init override breaking Copilot sign-in flow

### DIFF
--- a/programs/nvim/config/lua/plugins/copilot.lua
+++ b/programs/nvim/config/lua/plugins/copilot.lua
@@ -8,6 +8,7 @@ return {
   -- TODO: Replace copilot.vim with copilot-lsp inline completion when Neovim v0.12 is released (vim.lsp.inline_completion)
   {
     "github/copilot.vim",
+    lazy = false,
   },
   {
     -- https://github.com/AstroNvim/AstroNvim/blob/main/lua/astronvim/plugins/mason-tool-installer.lua

--- a/programs/nvim/config/lua/plugins/copilot.lua
+++ b/programs/nvim/config/lua/plugins/copilot.lua
@@ -2,9 +2,6 @@ return {
   {
     "copilotlsp-nvim/copilot-lsp",
     config = function()
-      vim.lsp.config("copilot_ls", {
-        on_init = function() end,
-      })
       vim.lsp.enable("copilot_ls")
     end,
   },


### PR DESCRIPTION
## Summary
- Remove the empty `on_init = function() end` override in copilot-lsp config
- This override was preventing copilot-lsp's `didChangeStatus` handler from triggering the automatic sign-in flow
- Without it, sidekick.nvim would show an error suggesting `:LspCopilotSignIn` which doesn't exist as a command

## Test plan
- [ ] Open Neovim and verify Copilot sign-in flow triggers automatically when not authenticated
- [ ] Verify no more `:LspCopilotSignIn` error messages from sidekick