### PR TITLE
feat(nix): add Japanese fonts to prevent tofu in Chrome

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -57,6 +57,10 @@
       gnumake
       claude-code
 
+      # Fonts
+      noto-fonts-cjk-sans
+      noto-fonts-cjk-serif
+
       # Networking
       ngrok
 
@@ -65,6 +69,8 @@
       google-cloud-sdk
     ];
   };
+
+  fonts.fontconfig.enable = true;
 
   manual.manpages.enable = false;
 


### PR DESCRIPTION
## Summary
- Add noto-fonts-cjk-sans and noto-fonts-cjk-serif packages for Japanese font support
- Enable fonts.fontconfig so installed fonts are registered with fontconfig
- Prevents tofu (□□□) rendering in Chrome for Japanese text

## Test plan
- [ ] Run `hms` to apply the configuration
- [ ] Open Chrome and verify Japanese text renders correctly