### PR TITLE
fix(nvim): restore copilot-lsp auto sign-in broken by sidekick handler override

### DIFF
--- a/programs/nvim/config/lua/plugins/copilot.lua
+++ b/programs/nvim/config/lua/plugins/copilot.lua
@@ -4,24 +4,27 @@ return {
     config = function()
       vim.lsp.enable("copilot_ls")
 
-      -- sidekick.nvim overwrites the didChangeStatus handler, which breaks
-      -- copilot-lsp's automatic sign-in flow. Re-attach the sign-in handler
-      -- so that it fires alongside sidekick's status handler.
-      vim.api.nvim_create_autocmd("LspAttach", {
+      -- sidekick.nvim overwrites the copilot_ls didChangeStatus handler,
+      -- which breaks copilot-lsp's automatic sign-in flow. Patch
+      -- sidekick's attach to chain copilot-lsp's sign-in handler.
+      vim.api.nvim_create_autocmd("User", {
+        pattern = "LazyLoad",
         group = vim.api.nvim_create_augroup("copilot-lsp-signin", { clear = true }),
         callback = function(ev)
-          local client = vim.lsp.get_client_by_id(ev.data.client_id)
-          if not client or client.name ~= "copilot_ls" then
+          if ev.data ~= "sidekick.nvim" then
             return
           end
-          local copilot_handlers = require("copilot-lsp.handlers")
-          local current = client.handlers.didChangeStatus
-          if current and current ~= copilot_handlers.didChangeStatus then
+          local sk_status = require("sidekick.status")
+          local original_attach = sk_status.attach
+          sk_status.attach = function(client)
+            original_attach(client)
+            local sidekick_handler = client.handlers.didChangeStatus
             client.handlers.didChangeStatus = function(err, res, ctx)
-              copilot_handlers.didChangeStatus(err, res, ctx)
-              current(err, res, ctx)
+              require("copilot-lsp.handlers").didChangeStatus(err, res, ctx)
+              sidekick_handler(err, res, ctx)
             end
           end
+          return true -- remove autocmd
         end,
       })
     end,

--- a/programs/nvim/config/lua/plugins/copilot.lua
+++ b/programs/nvim/config/lua/plugins/copilot.lua
@@ -3,6 +3,27 @@ return {
     "copilotlsp-nvim/copilot-lsp",
     config = function()
       vim.lsp.enable("copilot_ls")
+
+      -- sidekick.nvim overwrites the didChangeStatus handler, which breaks
+      -- copilot-lsp's automatic sign-in flow. Re-attach the sign-in handler
+      -- so that it fires alongside sidekick's status handler.
+      vim.api.nvim_create_autocmd("LspAttach", {
+        group = vim.api.nvim_create_augroup("copilot-lsp-signin", { clear = true }),
+        callback = function(ev)
+          local client = vim.lsp.get_client_by_id(ev.data.client_id)
+          if not client or client.name ~= "copilot_ls" then
+            return
+          end
+          local copilot_handlers = require("copilot-lsp.handlers")
+          local current = client.handlers.didChangeStatus
+          if current and current ~= copilot_handlers.didChangeStatus then
+            client.handlers.didChangeStatus = function(err, res, ctx)
+              copilot_handlers.didChangeStatus(err, res, ctx)
+              current(err, res, ctx)
+            end
+          end
+        end,
+      })
     end,
   },
   -- TODO: Replace copilot.vim with copilot-lsp inline completion when Neovim v0.12 is released (vim.lsp.inline_completion)


### PR DESCRIPTION
## Summary
- sidekick.nvim overwrites the copilot_ls client's `didChangeStatus` handler with its own, which breaks copilot-lsp's automatic sign-in flow
- This caused an error message suggesting `:LspCopilotSignIn` (a non-existent command) instead of triggering the browser-based device code auth flow
- Fix by wrapping the handler in `LspAttach` so both copilot-lsp's sign-in logic and sidekick's status handler fire together

## Test plan
- [ ] Open Neovim and verify Copilot sign-in flow triggers automatically when not authenticated
- [ ] Verify no more `:LspCopilotSignIn` error messages from sidekick
- [ ] Verify sidekick status notifications still work