### PR TITLE
feat(claude): allow gh issue create, gh issue edit, and gh pr edit in hooks

### DIFF
--- a/programs/claude/nownabe-claude-hooks.json
+++ b/programs/claude/nownabe-claude-hooks.json
@@ -14,6 +14,18 @@
       "git commit *": {
         "reason": "Allow git commit with multi-line messages",
         "multiline": true
+      },
+      "gh issue create *": {
+        "reason": "Allow gh issue create with multi-line body",
+        "multiline": true
+      },
+      "gh issue edit *": {
+        "reason": "Allow gh issue edit",
+        "multiline": true
+      },
+      "gh pr edit *": {
+        "reason": "Allow gh pr edit",
+        "multiline": true
       }
     },
     "forbiddenPatterns": {


### PR DESCRIPTION
## Summary
- Add allowed patterns for `gh issue create`, `gh issue edit`, and `gh pr edit` in claude-hooks config
- All patterns enable multiline support for body content

## Test plan
- [ ] Confirm `hms` applies successfully
- [ ] Verify `gh issue create`, `gh issue edit`, and `gh pr edit` commands are auto-approved