### PR TITLE
feat(claude): allow gh issue edit in permissions

### DIFF
--- a/programs/claude/settings.json
+++ b/programs/claude/settings.json
@@ -35,7 +35,8 @@
     ],
     "ask": [
       "Bash(gh api:*)",
-      "Bash(gh issue close:*)"
+      "Bash(gh issue close:*)",
+      "Bash(gh issue edit:*)"
     ],
     "deny": [
       "Bash(git -C :*)",


### PR DESCRIPTION
## Summary
- Add `gh issue edit` to the `ask` permissions list in Claude Code settings

## Test plan
- [ ] Verify `gh issue edit` prompts for confirmation instead of being denied