### PR TITLE
fix(nix): patch chikuwa binary to use Nix glibc

### DIFF
--- a/packages/chikuwa.nix
+++ b/packages/chikuwa.nix
@@ -1,10 +1,11 @@
 {
   lib,
-  stdenvNoCC,
+  stdenv,
   fetchurl,
+  autoPatchelfHook,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "chikuwa";
   version = "0.1.8";
 
@@ -14,6 +15,9 @@ stdenvNoCC.mkDerivation rec {
   };
 
   sourceRoot = ".";
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+  buildInputs = [ stdenv.cc.cc.lib ];
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
## Summary
- Fix GLIBC_2.39 not found error when running chikuwa on systems with older glibc (e.g., Ubuntu with GLIBC 2.35)
- Use autoPatchelfHook to relink the prebuilt binary against Nix's glibc
- Switch from stdenvNoCC to stdenv and add necessary build inputs

## Test plan
- [ ] Run `hms` to apply the configuration
- [ ] Run `chikuwa` and verify it starts without GLIBC errors