### PR TITLE
feat(nix): add pip to python3 packages

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -25,7 +25,7 @@
       jdk
       lua
       nodejs
-      python3
+      (python3.withPackages (ps: [ ps.pip ]))
       ruby
       deno
       bun


### PR DESCRIPTION
## Summary
- Add pip to the Nix-managed Python3 installation by using python3.withPackages
- Enables pip CLI usage in the user environment

## Test plan
- [ ] Run hms to apply the configuration
- [ ] Verify pip --version works