### PR TITLE
fix(nvim): use catppuccin-mocha colorscheme to avoid Neovim 0.12 built-in conflict

### DIFF
--- a/programs/nvim/config/lua/plugins/astroui.lua
+++ b/programs/nvim/config/lua/plugins/astroui.lua
@@ -3,6 +3,6 @@ return {
   "AstroNvim/astroui",
   ---@type AstroUIOpts
   opts = {
-    colorscheme = "catppuccin",
+    colorscheme = "catppuccin-mocha",
   },
 }

--- a/programs/nvim/config/lua/plugins/colorscheme.lua
+++ b/programs/nvim/config/lua/plugins/colorscheme.lua
@@ -3,7 +3,7 @@ return {
     "catppuccin/nvim",
     name = "catppuccin",
     lazy = false,
-    priority = 10001,
+    priority = 1000,
     opts = {
       flavour = "mocha",
       transparent_background = true,

--- a/programs/nvim/config/lua/plugins/colorscheme.lua
+++ b/programs/nvim/config/lua/plugins/colorscheme.lua
@@ -3,7 +3,7 @@ return {
     "catppuccin/nvim",
     name = "catppuccin",
     lazy = false,
-    priority = 1000,
+    priority = 10001,
     opts = {
       flavour = "mocha",
       transparent_background = true,


### PR DESCRIPTION
## Summary
- Use `catppuccin-mocha` instead of `catppuccin` as the colorscheme name in astroui config
- Revert catppuccin priority back to 1000 (the priority change was not needed)
- Neovim 0.12 bundles a built-in `catppuccin.vim` at `$VIMRUNTIME/colors/catppuccin.vim`. When `:colorscheme catppuccin` was called, Neovim loaded the built-in `.vim` file instead of the plugin's `colors/catppuccin.lua`, so the plugin's `setup()` options (`transparent_background`, `custom_highlights`, etc.) were completely ignored.
- Using `catppuccin-mocha` resolves to the plugin's `colors/catppuccin-mocha.lua` which has no built-in conflict.

## Test plan
- [ ] Open nvim and verify the background is transparent
- [ ] Verify `NormalFloat`, `FloatBorder`, `FloatTitle` have `bg = NONE`
- [ ] Verify `:lua print(vim.g.colors_name)` shows `catppuccin-mocha`