### PR TITLE
feat(nix): add mo markdown viewer package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,7 @@
       overlay = final: prev: {
         aqua = final.callPackage ./packages/aqua.nix { };
         chikuwa = final.callPackage ./packages/chikuwa.nix { };
+        mo = final.callPackage ./packages/mo.nix { };
       };
       pkgs = import nixpkgs {
         inherit system;

--- a/home.nix
+++ b/home.nix
@@ -57,6 +57,7 @@
       gnupg
       gnumake
       claude-code
+      mo
 
       # Fonts
       noto-fonts-cjk-sans

--- a/packages/mo.nix
+++ b/packages/mo.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "mo";
+  version = "1.3.0";
+
+  src = fetchurl {
+    url = "https://github.com/k1LoW/mo/releases/download/v${version}/mo_v${version}_linux_amd64.tar.gz";
+    hash = "sha256-BJn7yOmd2Ilb63BJo4La/KCGTxM28xFotKGwL09RYxM=";
+  };
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 mo $out/bin/mo
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Markdown viewer using browser";
+    homepage = "https://github.com/k1LoW/mo";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+    mainProgram = "mo";
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
## Summary
- Add mo (k1LoW/mo) markdown viewer as a Nix package
- Add package overlay in flake.nix and include in home.nix

## Test plan
- [x] Run `hms` to verify the package builds and installs successfully