### PR TITLE
feat(nix): add chromium browser package

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -69,6 +69,9 @@
       # Cloud
       awscli2
       google-cloud-sdk
+
+      # Applications
+      chromium
     ];
   };
 


### PR DESCRIPTION
## Summary
- Add `chromium` to the package list in `home.nix` under a new "Applications" section

## Test plan
- [x] `hms` applies successfully
- [x] `which chromium` resolves to `~/.nix-profile/bin/chromium`
- [x] `chromium --version` reports Chromium 148.0.7778.215
