### PR TITLE
fix(nix): migrate deprecated programs.ssh.matchBlocks to settings

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -102,8 +102,8 @@
       enable = true;
       enableDefaultConfig = false;
       includes = [ "~/.ssh/config.local" ];
-      matchBlocks."*" = {
-        addKeysToAgent = "yes";
+      settings."*" = {
+        AddKeysToAgent = "yes";
       };
     };
 


### PR DESCRIPTION
## Summary
- Migrate `programs.ssh.matchBlocks` to `programs.ssh.settings` to resolve Home Manager deprecation warning
- Update `addKeysToAgent` to `AddKeysToAgent` (upstream SSH directive naming)

## Test plan
- [x] `nix build` succeeds without deprecation warnings
- [ ] `hms` applies successfully