### PR TITLE
fix(nvim): disable Copilot Next Edit Suggestions

### DIFF
--- a/programs/nvim/config/lua/plugins/copilot.lua
+++ b/programs/nvim/config/lua/plugins/copilot.lua
@@ -9,6 +9,11 @@ return {
       local copilot_handlers = require("copilot-lsp.handlers")
       copilot_handlers.didChangeStatus = function() end
 
+      vim.lsp.config("copilot_ls", {
+        settings = {
+          nextEditSuggestions = { enabled = false },
+        },
+      })
       vim.lsp.enable("copilot_ls")
     end,
   },

--- a/programs/nvim/config/lua/plugins/sidekick.lua
+++ b/programs/nvim/config/lua/plugins/sidekick.lua
@@ -15,16 +15,6 @@ return {
   -- stylua: ignore
   keys = {
     {
-      "<tab>",
-      function()
-        if not require("sidekick").nes_jump_or_apply() then
-          return "<tab>"
-        end
-      end,
-      expr = true,
-      desc = "Goto/Apply Next Edit Suggestion",
-    },
-    {
       "<leader>ss",
       function() require("sidekick.cli").toggle() end,
       mode = { "n", "v" },


### PR DESCRIPTION
## Summary
- Disable NES (Next Edit Suggestions) in copilot_ls LSP settings
- Remove `<tab>` NES jump/apply keybinding from sidekick.nvim
- Sidekick CLI features (`<leader>s*` keymaps) are preserved

## Test plan
- [ ] Run `hms` to apply
- [ ] Open Neovim and confirm NES suggestions no longer appear
- [ ] Confirm Sidekick CLI keymaps still work (`<leader>ss`, `<leader>sc`, etc.)
- [ ] Confirm inline completion via copilot.vim still works