### PR TITLE
feat(nix): add devbox package

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -33,6 +33,7 @@
       # Package managers
       uv
       aqua
+      devbox
 
       # Nix tools
       nil


### PR DESCRIPTION
## Summary
- Add devbox to home-manager packages for instant, reproducible development environments

## Test plan
- [x] `nix build` succeeds
- [ ] Run `hms` to apply configuration
- [ ] Verify `devbox` command is available