### PR TITLE
docs(claude): add Bash tool usage rule against echo separators

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -33,6 +33,7 @@
       # Package managers
       uv
       aqua
+      devbox
 
       # Nix tools
       nil

--- a/programs/claude/CLAUDE.md
+++ b/programs/claude/CLAUDE.md
@@ -22,3 +22,7 @@ Available commands:
 - `gh resolve-tag-sha <owner/repo> <tag>` — resolve a tag to its commit SHA (useful for pinning GitHub Actions)
 
 All commands accept `--repo <owner/repo>` to target a specific repository (defaults to current repo).
+
+## Bash Tool Usage
+
+- Do not insert `echo "====="` or similar separator/marker commands between commands to visually confirm output boundaries. Each Bash tool call already returns its output clearly — use separate tool calls or `&&` chaining instead.


### PR DESCRIPTION
## Summary
- Add a rule to programs/claude/CLAUDE.md prohibiting echo separators in Bash tool calls
- Each Bash tool call already returns output clearly, so separator echoes are unnecessary noise

## Test plan
- [x] Verify the rule is correctly added to CLAUDE.md