### PR TITLE
feat(nix): add fcitx5 and mozc input method for native Linux

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -1,4 +1,4 @@
-{ pkgs, username, ... }:
+{ pkgs, lib, username, isWSL, ... }:
 
 {
   imports = [
@@ -75,6 +75,11 @@
 
       # Applications
       chromium
+    ] ++ lib.optionals (!isWSL) [
+      # Input method (native Linux only)
+      fcitx5
+      fcitx5-mozc
+      mozc # provides mozc_tool config GUI (apt: mozc-utils-gui)
     ];
   };
 


### PR DESCRIPTION
## Summary
- Add `fcitx5`, `fcitx5-mozc`, and `mozc` packages, gated to native Linux only (excluded on WSL2) via `lib.optionals (!isWSL)`
- `mozc` provides the `mozc_tool` config GUI — the nixpkgs equivalent of apt's `mozc-utils-gui` (there is no separate `mozc-utils-gui` attribute in nixpkgs)
- Thread `lib` and `isWSL` into `home.nix` (`isWSL` is already supplied via `extraSpecialArgs` in `flake.nix`)

## Test plan
- [x] `nix build .#homeConfigurations.linux.activationPackage` succeeds
- [x] `linux` config includes `fcitx5`, `fcitx5-mozc`, `mozc`
- [x] `wsl` config includes none of the input-method packages