### PR TITLE
docs(claude): strengthen rule against echo separators

### DIFF
--- a/programs/claude/CLAUDE.md
+++ b/programs/claude/CLAUDE.md
@@ -25,7 +25,7 @@ All commands accept `--repo <owner/repo>` to target a specific repository (defau
 
 ## Bash Tool Usage
 
-- Do not insert `echo "====="` or similar separator/marker commands between commands to visually confirm output boundaries. Each Bash tool call already returns its output clearly — use separate tool calls or `&&` chaining instead.
+- **NEVER insert `echo "====="` or similar separator/marker commands** between commands to visually confirm output boundaries. Each Bash tool call already returns its output clearly — use separate tool calls or `&&` chaining instead.
 - **NEVER use the Bash tool to write files** (no `cat >`, `echo >`, `tee`, heredocs, `sed -i`, etc.). Use the **Write** or **Edit** tool instead.
 - **NEVER use the Bash tool to read files** (no `cat`, `head`, `tail`, `less`, etc.). Use the **Read** tool instead.
 - **NEVER use the Bash tool to search** (no `grep`, `rg`, `find`, `ls`-as-search, etc.). Use the **Grep** or **Glob** tool instead.


### PR DESCRIPTION
## Summary
- Strengthen the existing rule in `programs/claude/CLAUDE.md` against inserting `echo "====="` or similar separator/marker commands, changing the soft "Do not" to a strong "**NEVER**"

## Test plan
- [ ] `hms` applies successfully
- [ ] `~/.claude/CLAUDE.md` reflects the strengthened rule