### PR TITLE
feat(nix): add google-chrome alongside chromium

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -76,6 +76,7 @@
 
       # Applications
       chromium
+      google-chrome
     ] ++ lib.optionals (!isWSL) [
       # Input method (native Linux only)
       fcitx5


### PR DESCRIPTION
## Summary
- Add `google-chrome` to `home.packages` alongside the existing `chromium`
- `config.allowUnfree = true` is already set in `flake.nix`, so no extra config is needed for this unfree package

## Test plan
- [x] `nix build .#homeConfigurations.wsl.activationPackage` succeeds
- [ ] `hms` applies cleanly and `google-chrome` is available
