### PR TITLE
feat(claude): forbid echo command in pre-bash hook

### DIFF
--- a/programs/claude/nownabe-claude-hooks.json
+++ b/programs/claude/nownabe-claude-hooks.json
@@ -42,6 +42,11 @@
         "type": "regex",
         "reason": "`$(cat` in `gh` commands is forbidden.",
         "suggestion": "Pass arguments directly (e.g., `--title \"title\" --body \"body\"`) instead of using `$(cat <<'EOF' ...)`."
+      },
+      "^echo\\b": {
+        "type": "regex",
+        "reason": "`echo` is forbidden.",
+        "suggestion": "Do not use `echo` for separators/markers or to write files. Use separate Bash calls, `&&` chaining, or the Write/Edit tools instead."
       }
     }
   }


### PR DESCRIPTION
## Summary
- Add a `forbiddenPatterns` rule (`^echo\b`) to `nownabe-claude-hooks.json` that denies `echo` commands via the pre-bash hook
- The rule enforces existing CLAUDE.md guidance: don't use `echo` for separators/markers or to write files
- Uses a start-anchored regex since the hook already splits compound commands on `&&`/`||`/`;`/`|` (quotes excluded) and trims each sub-command, so `echo` is always at the start — avoids false positives like `git commit -m "echo test"`

## Test plan
- [x] `jq` confirms valid JSON and the pattern is present
- [x] Verified live: `git status && echo ...` was denied by the hook, while a plain `git status` passed