### PR TITLE
feat(claude): forbid sed command in pre-bash hook

### DIFF
--- a/programs/claude/nownabe-claude-hooks.json
+++ b/programs/claude/nownabe-claude-hooks.json
@@ -47,6 +47,11 @@
         "type": "regex",
         "reason": "`echo` is forbidden.",
         "suggestion": "Do not use `echo` for separators/markers or to write files. Use separate Bash calls, `&&` chaining, or the Write/Edit tools instead."
+      },
+      "^sed\\b": {
+        "type": "regex",
+        "reason": "`sed` is forbidden.",
+        "suggestion": "Use the Edit or Read tool instead of `sed`."
       }
     }
   }


### PR DESCRIPTION
## Summary
- Add `^sed\b` to `forbiddenPatterns` in `nownabe-claude-hooks.json`
- Suggests using the Edit or Read tool instead of `sed`

## Test plan
- [x] `sed -i 's/foo/bar/g' file.txt` → denied with reason/suggestion
- [x] `git commit -m "sed is great"` → not denied (no false positive on quoted args)
