### PR TITLE
chore(claude): add .local/tmp as temp dir with session hook and git ignore

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,10 +34,6 @@ dotfiles/
 └── archived/                   # Old Chezmoi files (kept for reference)
 ```
 
-## Temporary Files
-
-Use `.local/tmp/` for temporary files within the working directory. This directory is created automatically at session start and is git-ignored.
-
 ## Pull Request Rules
 
 ### Branch

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,10 @@ dotfiles/
 └── archived/                   # Old Chezmoi files (kept for reference)
 ```
 
+## Temporary Files
+
+Use `.local/tmp/` for temporary files within the working directory. This directory is created automatically at session start and is git-ignored.
+
 ## Pull Request Rules
 
 ### Branch

--- a/programs/claude/CLAUDE.md
+++ b/programs/claude/CLAUDE.md
@@ -23,6 +23,10 @@ Available commands:
 
 All commands accept `--repo <owner/repo>` to target a specific repository (defaults to current repo).
 
+## Temporary Files
+
+- Use `.local/tmp/` for temporary files. It is created automatically at session start and is git-ignored globally.
+
 ## Bash Tool Usage
 
 - **NEVER insert `echo "====="` or similar separator/marker commands** between commands to visually confirm output boundaries. Each Bash tool call already returns its output clearly — use separate tool calls or `&&` chaining instead.

--- a/programs/claude/settings.json
+++ b/programs/claude/settings.json
@@ -69,7 +69,6 @@
       "Bash(gh issue close:*)"
     ]
   },
-  "model": "sonnet",
   "hooks": {
     "SessionStart": [
       {

--- a/programs/claude/settings.json
+++ b/programs/claude/settings.json
@@ -33,6 +33,8 @@
       "Bash(git show:*)",
       "Bash(git status:*)",
       "Bash(grep:*)",
+      "Read(.local/**)",
+      "Write(.local/tmp/**)",
       "Bash(go test:*)",
       "Bash(npm info:*)",
       "mcp__plugin_context7_context7__*",
@@ -67,6 +69,7 @@
       "Bash(gh issue close:*)"
     ]
   },
+  "model": "sonnet",
   "hooks": {
     "SessionStart": [
       {
@@ -74,6 +77,14 @@
           {
             "type": "command",
             "command": "chikuwa hook"
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "mkdir -p .local/tmp"
           }
         ]
       }

--- a/programs/git/default.nix
+++ b/programs/git/default.nix
@@ -9,6 +9,7 @@ in
     enable = true;
 
     ignores = [
+      ".local/"
       ".nownabe/"
       ".shogo/"
       ".worktrees/"


### PR DESCRIPTION
## Summary

- Add `SessionStart` hook in `settings.json` to run `mkdir -p .local/tmp` automatically
- Add `Read(.local/**)` and `Write(.local/tmp/**)` to allowed permissions
- Add `.local/` to global git ignore in `programs/git/default.nix`
- Document `.local/tmp/` as the standard temp directory in the global `programs/claude/CLAUDE.md`

## Test plan

- [ ] Verify `hms` applies cleanly
- [ ] Start a new Claude Code session and confirm `.local/tmp/` is created automatically
- [ ] Confirm `.local/` is not tracked by git in repos
