### PR TITLE
chore(nix): update chikuwa to 0.1.9

### DIFF
--- a/packages/chikuwa.nix
+++ b/packages/chikuwa.nix
@@ -7,11 +7,11 @@
 
 stdenv.mkDerivation rec {
   pname = "chikuwa";
-  version = "0.1.8";
+  version = "0.1.9";
 
   src = fetchurl {
     url = "https://github.com/nownabe/chikuwa/releases/download/v${version}/chikuwa-x86_64-unknown-linux-gnu.tar.gz";
-    hash = "sha256-MtrZa6FXPw6+AjlY7RLSmhoZWotQ6f8giGc3hoXJn6s=";
+    hash = "sha256-ZKkW4glVgfz7BxKnqdoSv74mk/jirrXrToIHemYIM6k=";
   };
 
   sourceRoot = ".";


### PR DESCRIPTION
## Summary

- Update `chikuwa` from v0.1.8 to v0.1.9
- Upstream fix: exit silently when hook runs outside tmux (nownabe/chikuwa#45)

## Test plan

- [x] `nix build` of `packages/chikuwa.nix` succeeds
- [x] Built binary reports `chikuwa 0.1.9`
- [ ] `hms` applies cleanly