### PR TITLE
feat(nvim): disable sidekick NES (next edit suggestions)

### DIFF
--- a/programs/nvim/config/lua/plugins/sidekick.lua
+++ b/programs/nvim/config/lua/plugins/sidekick.lua
@@ -3,6 +3,8 @@ return {
   dependencies = { "copilotlsp-nvim/copilot-lsp" },
   event = "LspAttach",
   opts = {
+    -- Disable Next Edit Suggestions (NES); use only the AI CLI integration.
+    nes = { enabled = false },
     copilot = {
       status = {
         -- Suppress "not signed in" notification during startup.


### PR DESCRIPTION
## Summary

- Disable Next Edit Suggestions (NES) in sidekick.nvim by setting `nes = { enabled = false }`
- Keep only the AI CLI integration active

## Test plan

- [ ] Run `hms` to apply the Home Manager configuration
- [ ] Restart Neovim and confirm NES suggestions no longer appear
- [ ] Confirm sidekick CLI keymaps (`<leader>ss`, etc.) still work
