### PR TITLE
feat(zsh): add tf alias for terraform

### DIFF
--- a/programs/zsh/default.nix
+++ b/programs/zsh/default.nix
@@ -79,6 +79,7 @@ in
       bat = "batcat";
       vi = "nvim";
       g = "git";
+      tf = "terraform";
 
       # Ruby
       bi = "bundle install";


### PR DESCRIPTION
## Summary

- Add `tf` shell alias for `terraform` in zsh config

## Test plan

- [ ] Run `hms` to apply
- [ ] Verify `tf` resolves to `terraform`