### PR TITLE
feat(zsh): add bat

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -92,6 +92,8 @@
   programs = {
     home-manager.enable = true;
 
+    bat.enable = true;
+
     direnv = {
       enable = true;
       enableZshIntegration = true;

--- a/programs/zsh/config/fzf.zsh
+++ b/programs/zsh/config/fzf.zsh
@@ -9,9 +9,9 @@ export FZF_DEFAULT_OPTS="
   --history=${XDG_CACHE_HOME:-$HOME/.cache}/fzf/history
   --history-size=10000
   --bind=ctrl-j:down,ctrl-k:up
-  --preview 'batcat --color=always --style=numbers --line-range :500 {}'"
+  --preview 'bat --color=always --style=numbers --line-range :500 {}'"
 
-export FZF_CTRL_T_OPTS="--preview 'batcat --color=always --style=numbers --line-range :500 {}'"
+export FZF_CTRL_T_OPTS="--preview 'bat --color=always --style=numbers --line-range :500 {}'"
 
 export FZF_CTRL_R_OPTS="
   --bind 'ctrl-y:execute-silent(echo -n {2..} | pbcopy)+abort'
@@ -23,7 +23,7 @@ export FZF_CTRL_R_OPTS="
 
 function fzf-ghq() {
   local target_dir
-  target_dir=$(ghq list | fzf --no-multi --preview "batcat --color=always --style=header,grid --line-range :80 $(ghq root)/{}/README.md")
+  target_dir=$(ghq list | fzf --no-multi --preview "bat --color=always --style=header,grid --line-range :80 $(ghq root)/{}/README.md")
   if [[ -n "$target_dir" ]]; then
     cd $(ghq root)/$target_dir
     zle accept-line

--- a/programs/zsh/default.nix
+++ b/programs/zsh/default.nix
@@ -76,7 +76,6 @@ in
 
       # General commands
       k = "kubectl";
-      bat = "batcat";
       vi = "nvim";
       g = "git";
       tf = "terraform";


### PR DESCRIPTION
## Summary

- Enable `bat` via `programs.bat.enable` in `home.nix`
- Remove the now-obsolete `bat = "batcat"` zsh alias (the Nix package installs the command as `bat`, not the Ubuntu/apt `batcat` name)
- Replace `batcat` references in `fzf.zsh` previews with `bat`

## Test plan

- [ ] Run `hms` to apply the configuration
- [ ] Verify `bat <file>` works
- [ ] Verify fzf preview (Ctrl-T) and `fzf-ghq` render with `bat`
