### PR TITLE
feat(git): ignore .claude/worktrees globally

### DIFF
--- a/programs/git/default.nix
+++ b/programs/git/default.nix
@@ -13,6 +13,7 @@ in
       ".nownabe/"
       ".shogo/"
       ".worktrees/"
+      ".claude/worktrees/"
       "**/.claude/settings.local.json"
     ];
 


### PR DESCRIPTION
## Summary

- Add `.claude/worktrees/` to the global gitignore (`programs.git.ignores`)

## Test plan

- [ ] Run `hms` and confirm `.claude/worktrees/` appears in `~/.config/git/ignore`
- [ ] Verify a `.claude/worktrees` directory is ignored by git