### PR TITLE
feat(git): chain repo-local hooks through global hooksPath

### DIFF
--- a/programs/claude/scripts/statusline-command.sh
+++ b/programs/claude/scripts/statusline-command.sh
@@ -5,7 +5,6 @@ input=$(cat)
 
 # Colors (ANSI)
 RESET="\033[0m"
-BOLD="\033[1m"
 DIM="\033[2m"
 GREEN="\033[32m"
 CYAN="\033[36m"
@@ -13,7 +12,6 @@ MAGENTA="\033[35m"
 YELLOW="\033[33m"
 BLUE="\033[34m"
 GRAY="\033[90m"
-WHITE="\033[97m"
 
 # Extract from Claude Code JSON input
 MODEL=$(echo "$input" | jq -r '.model.display_name // empty')

--- a/programs/git/default.nix
+++ b/programs/git/default.nix
@@ -3,6 +3,35 @@
 let
   githubName = "nownabe";
   githubEmail = "1286807+nownabe@users.noreply.github.com";
+
+  # Standard client-side Git hooks that should chain through to each
+  # repository's own .git/hooks/<name>. Because core.hooksPath is set,
+  # Git ignores repo-local hooks unless a global hook of the same name
+  # forwards to them. post-checkout is intentionally excluded here: it has
+  # its own script that runs global worktree-symlink logic and chains too.
+  chainedHooks = [
+    "applypatch-msg"
+    "pre-applypatch"
+    "post-applypatch"
+    "pre-commit"
+    "pre-merge-commit"
+    "prepare-commit-msg"
+    "commit-msg"
+    "post-commit"
+    "pre-rebase"
+    "post-merge"
+    "pre-push"
+    "post-rewrite"
+    "pre-auto-gc"
+  ];
+
+  chainedHookFiles = lib.listToAttrs (map (name: {
+    name = ".config/git/hooks/${name}";
+    value = {
+      source = ./hooks/chain-local;
+      executable = true;
+    };
+  }) chainedHooks);
 in
 {
   programs.git = {
@@ -55,7 +84,7 @@ in
     };
   };
 
-  home.file = {
+  home.file = chainedHookFiles // {
     ".local/bin/git-clean-squashed" = {
       source = ./scripts/git-clean-squashed;
       executable = true;

--- a/programs/git/hooks/chain-local
+++ b/programs/git/hooks/chain-local
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# Global hook dispatcher.
+#
+# Because core.hooksPath is set globally, Git ignores every repository's
+# own .git/hooks/ directory. This script is installed under the global
+# hooks path for each standard hook name and simply chains to the matching
+# repo-local hook, restoring per-repo hooks (e.g. those written by
+# `mise generate git-pre-commit --write` or pre-commit frameworks).
+#
+# The hook to run is derived from the name this script is invoked as
+# (argv[0]); install it as a symlink named after each hook.
+
+set -o nounset
+
+hook_name=$(basename "$0")
+
+# git-common-dir points at the real .git of the repo/worktree; unlike
+# hooksPath it always resolves to the per-repo hooks directory.
+common_dir=$(git rev-parse --git-common-dir 2>/dev/null) || exit 0
+local_hook="$common_dir/hooks/$hook_name"
+
+[[ -x "$local_hook" ]] || exit 0
+
+# Guard against infinite recursion if the global hooks path ever points at
+# the repo-local .git/hooks (i.e. we'd invoke ourselves).
+if [[ "$(realpath "$local_hook")" == "$(realpath "$0")" ]]; then
+  exit 0
+fi
+
+exec "$local_hook" "$@"

--- a/programs/git/hooks/chain-local.test.sh
+++ b/programs/git/hooks/chain-local.test.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+#
+# Tests for the global chain-local hook dispatcher.
+# Run: bash programs/git/hooks/chain-local.test.sh
+
+set -o nounset
+set -o pipefail
+
+DISPATCHER="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/chain-local"
+
+# Isolate from the user's global/system git config so the real global
+# hooksPath never fires, and commits don't sign.
+export GIT_CONFIG_GLOBAL=/dev/null
+export GIT_CONFIG_SYSTEM=/dev/null
+export GIT_AUTHOR_NAME=test GIT_AUTHOR_EMAIL=test@example.com
+export GIT_COMMITTER_NAME=test GIT_COMMITTER_EMAIL=test@example.com
+
+PASS=0
+FAIL=0
+ok()   { PASS=$((PASS + 1)); }
+fail() { printf '  FAIL: %s\n' "$1"; FAIL=$((FAIL + 1)); }
+
+# Create a non-bare repo with one commit at $1.
+make_repo() {
+  git init -q "$1"
+  git -C "$1" commit -q --allow-empty -m init
+}
+
+# Install the dispatcher as <hooks-path>/<name> and invoke it inside $repo.
+# Usage: run_dispatch <repo> <hook-name> [args...]
+run_dispatch() {
+  local repo=$1 name=$2; shift 2
+  local dir; dir=$(mktemp -d)
+  ln -s "$DISPATCHER" "$dir/$name"
+  ( cd "$repo" && "$dir/$name" "$@" )
+  local rc=$?
+  rm -rf "$dir"
+  return $rc
+}
+
+test_chains_local_pre_commit() {
+  local repo; repo=$(mktemp -d)
+  make_repo "$repo"
+  {
+    printf '#!/usr/bin/env bash\n'
+    printf 'touch "%s/.pre-commit-ran"\n' "$repo"
+  } > "$repo/.git/hooks/pre-commit"
+  chmod +x "$repo/.git/hooks/pre-commit"
+
+  run_dispatch "$repo" pre-commit
+
+  if [[ -f "$repo/.pre-commit-ran" ]]; then ok; else fail "local pre-commit was not chained"; fi
+
+  rm -rf "$repo"
+}
+
+test_passes_arguments_through() {
+  local repo; repo=$(mktemp -d)
+  make_repo "$repo"
+  {
+    printf '#!/usr/bin/env bash\n'
+    printf 'printf "%%s" "$1" > "%s/.args"\n' "$repo"
+  } > "$repo/.git/hooks/commit-msg"
+  chmod +x "$repo/.git/hooks/commit-msg"
+
+  run_dispatch "$repo" commit-msg .git/COMMIT_EDITMSG
+
+  if [[ "$(cat "$repo/.args" 2>/dev/null)" == ".git/COMMIT_EDITMSG" ]]; then
+    ok
+  else
+    fail "argument not forwarded: $(cat "$repo/.args" 2>/dev/null)"
+  fi
+
+  rm -rf "$repo"
+}
+
+test_missing_local_hook_is_noop() {
+  local repo; repo=$(mktemp -d)
+  make_repo "$repo"   # no repo-local pre-push hook
+
+  if run_dispatch "$repo" pre-push; then ok; else fail "dispatcher failed when no local hook exists"; fi
+
+  rm -rf "$repo"
+}
+
+test_non_executable_local_hook_is_skipped() {
+  local repo; repo=$(mktemp -d)
+  make_repo "$repo"
+  printf '#!/usr/bin/env bash\nexit 1\n' > "$repo/.git/hooks/pre-commit"  # not chmod +x
+
+  if run_dispatch "$repo" pre-commit; then ok; else fail "non-executable local hook was run"; fi
+
+  rm -rf "$repo"
+}
+
+test_propagates_exit_code() {
+  local repo; repo=$(mktemp -d)
+  make_repo "$repo"
+  printf '#!/usr/bin/env bash\nexit 7\n' > "$repo/.git/hooks/pre-commit"
+  chmod +x "$repo/.git/hooks/pre-commit"
+
+  run_dispatch "$repo" pre-commit
+  if [[ $? -eq 7 ]]; then ok; else fail "exit code not propagated"; fi
+
+  rm -rf "$repo"
+}
+
+test_chains_from_linked_worktree() {
+  local repo; repo=$(mktemp -d)
+  make_repo "$repo"
+  {
+    printf '#!/usr/bin/env bash\n'
+    printf 'touch "%s/.pre-commit-ran"\n' "$repo"
+  } > "$repo/.git/hooks/pre-commit"
+  chmod +x "$repo/.git/hooks/pre-commit"
+  git -C "$repo" worktree add -q -b feat "$repo/.worktrees/wt-001" >/dev/null 2>&1
+
+  run_dispatch "$repo/.worktrees/wt-001" pre-commit
+
+  # The linked worktree shares the common dir's hooks, so the hook must fire.
+  if [[ -f "$repo/.pre-commit-ran" ]]; then ok; else fail "hook not chained from linked worktree"; fi
+
+  rm -rf "$repo"
+}
+
+# --- runner ---
+for t in $(declare -F | awk '{print $3}' | grep '^test_'); do
+  printf '# %s\n' "$t"
+  "$t"
+done
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/programs/git/hooks/chain-local.test.sh
+++ b/programs/git/hooks/chain-local.test.sh
@@ -59,6 +59,8 @@ test_passes_arguments_through() {
   make_repo "$repo"
   {
     printf '#!/usr/bin/env bash\n'
+    # $1 is the generated hook's own positional arg, not this script's.
+    # shellcheck disable=SC2016
     printf 'printf "%%s" "$1" > "%s/.args"\n' "$repo"
   } > "$repo/.git/hooks/commit-msg"
   chmod +x "$repo/.git/hooks/commit-msg"


### PR DESCRIPTION
## Summary

- `core.hooksPath` is set globally (`~/.config/git/hooks`), which makes Git ignore every repository's own `.git/hooks/` directory. Repo-local hooks — e.g. those written by `mise generate git-pre-commit --write` or pre-commit frameworks — were generated but never fired.
- Add a generic `chain-local` dispatcher installed under the global hooks path for every standard client-side hook name (`pre-commit`, `commit-msg`, `pre-push`, etc.). It derives the hook name from `argv[0]` and forwards to the matching repo-local `.git/hooks/<name>`.
- `post-checkout` is intentionally left on its own script, which already runs the global worktree-symlink logic and chains to the local hook.
- Add `chain-local.test.sh` covering chaining, argument pass-through, exit-code propagation, missing/non-executable local hooks, and linked worktrees.

## Test plan

- [x] `bash programs/git/hooks/chain-local.test.sh` — 6 passed, 0 failed
- [x] `bash programs/git/hooks/post-checkout.test.sh` — 17 passed, 0 failed (unchanged)
- [x] `nix build .#homeConfigurations.wsl.activationPackage` succeeds; generated `~/.config/git/hooks/` contains all chained hook symlinks plus the standalone `post-checkout`
- [x] E2E: with `core.hooksPath` pointed at the generated dir, a repo-local `.git/hooks/pre-commit` fires on a real `git commit`