### PR TITLE
fix(claude): allow Edit instead of Write for .local/tmp

### DIFF
--- a/programs/claude/settings.json
+++ b/programs/claude/settings.json
@@ -34,7 +34,7 @@
       "Bash(git status:*)",
       "Bash(grep:*)",
       "Read(.local/**)",
-      "Write(.local/tmp/**)",
+      "Edit(.local/tmp/**)",
       "Bash(go test:*)",
       "Bash(npm info:*)",
       "mcp__plugin_context7_context7__*",


### PR DESCRIPTION
## Summary

- Replace `Write(.local/tmp/**)` with `Edit(.local/tmp/**)` in the Claude Code permission allowlist

Note: this removes `Write` from the allowlist, so creating a new file under `.local/tmp/` will require confirmation each time. Only edits to existing files are auto-allowed.

## Test plan

- [ ] `hms` applies successfully
- [ ] Editing an existing file under `.local/tmp/` is allowed without a prompt
