### PR TITLE
fix(nix): use wsl-open for BROWSER on WSL

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -78,6 +78,9 @@
       # Applications
       chromium
       google-chrome
+    ] ++ lib.optionals isWSL [
+      # Open URLs/files with the Windows-side default app (WSL only)
+      wsl-open
     ] ++ lib.optionals (!isWSL) [
       # Input method (native Linux only)
       fcitx5

--- a/programs/zsh/config/wsl.zsh
+++ b/programs/zsh/config/wsl.zsh
@@ -2,5 +2,5 @@ if grep -qi "WSL2" /proc/version 2>/dev/null; then
   echo_info "Running inside WSL2"
   export IS_WSL="true"
   export GPG_TTY="$(tty)"
-  export BROWSER="/usr/bin/wslview"
+  export BROWSER="wsl-open"
 fi


### PR DESCRIPTION
## Summary

- `BROWSER` on WSL pointed at `/usr/bin/wslview`, but `wslu` was never installed anywhere. With the variable pointing at a nonexistent binary, tools like `gcloud auth login` fell back to the Nix-installed Linux Chrome running under WSLg, which breaks Context-Aware Access — the browser has to be the Windows-side one.
- `wslu` is no longer packaged in nixpkgs (removed: the project is discontinued and its repository archived), so this uses `wsl-open` instead, which hands URLs/files to the Windows default app.
- Add `wsl-open` to `home.packages` under a new `lib.optionals isWSL` block, mirroring the existing `lib.optionals (!isWSL)` block — the tool is meaningless on native Linux.
- Change `export BROWSER="/usr/bin/wslview"` to `export BROWSER="wsl-open"` so it resolves via `PATH` (Nix installs to `~/.nix-profile/bin`, not `/usr/bin`).

## Test plan

- [x] `home-manager switch --flake .#wsl` succeeds
- [x] `which wsl-open` resolves to `~/.nix-profile/bin/wsl-open`
- [x] `wsl-open https://example.com` exits 0 and opens the URL in the Windows-side browser
- [ ] `gcloud auth login` opens the Windows-side browser and completes Context-Aware Access
