### PR TITLE
feat(claude): manage user-level skills via home manager and add worktree skill

### DIFF
--- a/programs/claude/default.nix
+++ b/programs/claude/default.nix
@@ -13,5 +13,8 @@
 
     ".claude/scripts/statusline-command.sh".source =
       config.lib.file.mkOutOfStoreSymlink "${dotfilesDir}/programs/claude/scripts/statusline-command.sh";
+
+    ".claude/skills".source =
+      config.lib.file.mkOutOfStoreSymlink "${dotfilesDir}/programs/claude/skills";
   };
 }

--- a/programs/claude/skills/worktree/SKILL.md
+++ b/programs/claude/skills/worktree/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: worktree
+description: >
+  Switch to an isolated git worktree before starting work. Use when the user
+  invokes /worktree or asks to work in a worktree (e.g., "worktree で作業して",
+  "work in a worktree").
+---
+
+# Worktree
+
+Move the session into an isolated git worktree so that subsequent work does not
+touch the main working directory.
+
+Call the `EnterWorktree` tool. It is a deferred tool, so load its schema first
+with `ToolSearch("select:EnterWorktree")` if it is not already available.
+
+If arguments are provided, use them as the worktree name. After entering the
+worktree, continue with whatever task the user gives next.


### PR DESCRIPTION
## Summary

- Manage user-level Claude Code skills (`~/.claude/skills`) via Home Manager by symlinking the whole directory to `programs/claude/skills` with `mkOutOfStoreSymlink`
- Add a `worktree` skill (`/worktree`) that switches the session into an isolated git worktree using the `EnterWorktree` tool

## Test plan

- [x] `home-manager switch --flake "$HOME/.dotfiles#wsl"` succeeds
- [x] `~/.claude/skills` resolves to `programs/claude/skills` in the repository
- [x] `~/.claude/skills/worktree/SKILL.md` is available
