### PR TITLE
feat(git): read worktree symlink config from .worktree-symlinks file

### DIFF
--- a/programs/git/README.md
+++ b/programs/git/README.md
@@ -1,0 +1,48 @@
+# Git
+
+Git configuration managed via `programs.git` in `default.nix`, plus global hooks and helper scripts.
+
+## Global Hooks
+
+`core.hooksPath` points at `~/.config/git/hooks`, which means Git ignores every repository's own `.git/hooks/`. The hooks deployed there restore repo-local hooks by chaining to them:
+
+- **`hooks/chain-local`** — installed under each standard hook name (`pre-commit`, `commit-msg`, etc.). Simply forwards to the matching repo-local `.git/hooks/<name>` if it exists and is executable.
+- **`hooks/post-checkout`** — chains to the repo-local `post-checkout` first, then runs the worktree-symlink logic below.
+
+## Worktree Symlinks (`.worktree-symlinks`)
+
+When a new linked worktree is created (e.g. `git worktree add`), the `post-checkout` hook symlinks files from the main worktree into the new worktree. This is useful for untracked local files such as `.env` or `.claude/settings.local.json` that every worktree needs.
+
+### Configuration
+
+Create a `.worktree-symlinks` file at the repository root (main worktree). One repo-root-relative path per line; blank lines and `#` comments are allowed:
+
+```
+# local files shared across worktrees
+.env
+.claude/settings.local.json
+```
+
+The file can be committed and shared, or kept local (gitignored) — both work.
+
+### Behavior
+
+- Fires only on worktree creation (previous HEAD is the null OID), in a linked worktree of a non-bare repository. Ordinary checkouts, the main worktree, and bare repositories are skipped.
+- Creates relative symlinks pointing back to the main worktree (e.g. `.env -> ../../.env`).
+- Never clobbers: an existing symlink is left as is (silently); an existing real file/directory is skipped with a warning.
+- A missing source in the main worktree is skipped with a warning.
+- Absolute paths and paths containing `..` are rejected with a warning, since the config file may be committed by others.
+
+### Tests
+
+```shell
+bash programs/git/hooks/post-checkout.test.sh
+bash programs/git/hooks/chain-local.test.sh
+```
+
+## Scripts
+
+Installed to `~/.local/bin`:
+
+- **`git-wt-helper`** — worktree helper behind the `git wt` workflow. Creates or switches to a worktree for a branch, reuses worktrees whose branches are already merged (including squash merges), and offers fzf selection when run without arguments. Supports both bare repos (`<repo>/wt-xxx/`) and non-bare repos (`<repo>/.worktrees/wt-xxx/`). See `git-wt-helper --help`.
+- **`git-clean-squashed`** — deletes local branches whose changes are already merged into the default branch, including squash-merged branches.

--- a/programs/git/hooks/post-checkout
+++ b/programs/git/hooks/post-checkout
@@ -2,23 +2,41 @@
 #
 # Global post-checkout hook.
 #
-# On worktree creation, symlinks files listed in the per-repo multi-valued
-# config `nownabe.worktreeSymlink` from the main worktree into the new
-# worktree (relative links). Only fires for non-bare repos, in a linked
-# worktree, when the previous HEAD is the null OID.
+# On worktree creation, symlinks files listed in `.worktree-symlinks` at the
+# main worktree root (one repo-root-relative path per line; blank lines and
+# `#` comments allowed) from the main worktree into the new worktree
+# (relative links). Only fires for non-bare repos, in a linked worktree,
+# when the previous HEAD is the null OID.
 
 set -o nounset
 set -o pipefail
 
 NULL_OID="0000000000000000000000000000000000000000"
 PREFIX="worktree-symlink"
+CONFIG_FILE=".worktree-symlinks"
 
 create_symlinks() {
   local main_worktree=$1 current_worktree=$2
+  local config="$main_worktree/$CONFIG_FILE"
   local rel source target target_dir link_target
 
-  while IFS= read -r rel; do
-    [[ -z "$rel" ]] && continue
+  [[ -f "$config" ]] || return 0
+
+  while IFS= read -r rel || [[ -n "$rel" ]]; do
+    # Trim surrounding whitespace (also handles CRLF line endings).
+    rel="${rel#"${rel%%[![:space:]]*}"}"
+    rel="${rel%"${rel##*[![:space:]]}"}"
+
+    # Skip blank lines and comments.
+    [[ -z "$rel" || "$rel" == \#* ]] && continue
+
+    # The config file may be committed and shared; never follow paths that
+    # could escape the worktree.
+    if [[ "$rel" == /* || "$rel" == .. || "$rel" == ../* || "$rel" == */../* || "$rel" == */.. ]]; then
+      printf '%s: warning: unsafe path, skipping: %s\n' "$PREFIX" "$rel" >&2
+      continue
+    fi
+
     source="$main_worktree/$rel"
     target="$current_worktree/$rel"
 
@@ -50,7 +68,7 @@ create_symlinks() {
     else
       printf '%s: error: failed to create symlink for %s\n' "$PREFIX" "$rel" >&2
     fi
-  done < <(git config --get-all nownabe.worktreeSymlink 2>/dev/null)
+  done < "$config"
 }
 
 chain_local_hook() {

--- a/programs/git/hooks/post-checkout.test.sh
+++ b/programs/git/hooks/post-checkout.test.sh
@@ -52,7 +52,7 @@ make_bare_with_worktree() {
 test_creates_relative_symlink() {
   local repo; repo=$(mktemp -d)
   make_repo "$repo"
-  git -C "$repo" config --add nownabe.worktreeSymlink .env
+  printf '.env\n' > "$repo/.worktree-symlinks"
   printf 'SECRET=1\n' > "$repo/.env"
   add_worktree "$repo"
 
@@ -74,7 +74,7 @@ test_creates_relative_symlink() {
 test_existing_symlink_is_silent() {
   local repo; repo=$(mktemp -d)
   make_repo "$repo"
-  git -C "$repo" config --add nownabe.worktreeSymlink .env
+  printf '.env\n' > "$repo/.worktree-symlinks"
   printf 'SECRET=1\n' > "$repo/.env"
   add_worktree "$repo"
   local wt="$repo/.worktrees/wt-001"
@@ -94,7 +94,7 @@ test_existing_symlink_is_silent() {
 test_non_symlink_is_not_clobbered() {
   local repo; repo=$(mktemp -d)
   make_repo "$repo"
-  git -C "$repo" config --add nownabe.worktreeSymlink .env
+  printf '.env\n' > "$repo/.worktree-symlinks"
   printf 'SECRET=1\n' > "$repo/.env"
   add_worktree "$repo"
   local wt="$repo/.worktrees/wt-001"
@@ -113,7 +113,7 @@ test_non_symlink_is_not_clobbered() {
 test_missing_source_warns() {
   local repo; repo=$(mktemp -d)
   make_repo "$repo"
-  git -C "$repo" config --add nownabe.worktreeSymlink .env   # no .env created
+  printf '.env\n' > "$repo/.worktree-symlinks"   # no .env created
   add_worktree "$repo"
   local wt="$repo/.worktrees/wt-001"
 
@@ -129,7 +129,7 @@ test_missing_source_warns() {
 test_non_creation_checkout_is_skipped() {
   local repo; repo=$(mktemp -d)
   make_repo "$repo"
-  git -C "$repo" config --add nownabe.worktreeSymlink .env
+  printf '.env\n' > "$repo/.worktree-symlinks"
   printf 'SECRET=1\n' > "$repo/.env"
   add_worktree "$repo"
   local wt="$repo/.worktrees/wt-001"
@@ -147,7 +147,7 @@ test_non_creation_checkout_is_skipped() {
 test_main_worktree_is_skipped() {
   local repo; repo=$(mktemp -d)
   make_repo "$repo"
-  git -C "$repo" config --add nownabe.worktreeSymlink .env
+  printf '.env\n' > "$repo/.worktree-symlinks"
   printf 'SECRET=1\n' > "$repo/.env"
 
   # Run inside the MAIN worktree with a creation-style prev HEAD.
@@ -163,7 +163,7 @@ test_main_worktree_is_skipped() {
 test_bare_repo_is_skipped() {
   local base; base=$(mktemp -d)
   local wt; wt=$(make_bare_with_worktree "$base")
-  git -C "$base/repo.git" config --add nownabe.worktreeSymlink .env
+  printf '.env\n' > "$wt/.worktree-symlinks"
 
   local out; out=$(mktemp)
   run_hook_create "$wt" "$out"
@@ -193,6 +193,57 @@ test_chains_local_hook() {
   if [[ -f "$repo/.local-hook-ran" ]]; then ok; else fail "local hook was not chained"; fi
 
   rm -rf "$repo"
+}
+
+test_no_config_file_is_silent() {
+  local repo; repo=$(mktemp -d)
+  make_repo "$repo"
+  add_worktree "$repo"
+  local wt="$repo/.worktrees/wt-001"
+
+  local out; out=$(mktemp)
+  run_hook_create "$wt" "$out"
+
+  if [[ -s "$out" ]]; then fail "missing config file produced output: $(cat "$out")"; else ok; fi
+
+  rm -rf "$repo" "$out"
+}
+
+test_comments_and_blank_lines_are_skipped() {
+  local repo; repo=$(mktemp -d)
+  make_repo "$repo"
+  printf '# local files\n\n  .env  \n' > "$repo/.worktree-symlinks"
+  printf 'SECRET=1\n' > "$repo/.env"
+  add_worktree "$repo"
+  local wt="$repo/.worktrees/wt-001"
+
+  local out; out=$(mktemp)
+  run_hook_create "$wt" "$out"
+
+  if [[ -L "$wt/.env" ]]; then ok; else fail "symlink not created from commented config"; fi
+  if grep -q 'warning' "$out"; then fail "comment/blank lines emitted warnings: $(cat "$out")"; else ok; fi
+
+  rm -rf "$repo" "$out"
+}
+
+test_unsafe_paths_are_rejected() {
+  local repo; repo=$(mktemp -d)
+  make_repo "$repo"
+  printf '/etc/passwd\n../outside\nsub/../outside\n' > "$repo/.worktree-symlinks"
+  add_worktree "$repo"
+  local wt="$repo/.worktrees/wt-001"
+
+  local out; out=$(mktemp)
+  run_hook_create "$wt" "$out"
+
+  if [[ -e "$repo/outside" || -L "$repo/outside" ]]; then fail "symlink escaped the worktree"; else ok; fi
+  if [[ "$(grep -c 'unsafe path' "$out")" -eq 3 ]]; then
+    ok
+  else
+    fail "expected 3 unsafe-path warnings: $(cat "$out")"
+  fi
+
+  rm -rf "$repo" "$out"
 }
 
 # --- runner ---


### PR DESCRIPTION
## Summary

- Replace the per-repo `git config nownabe.worktreeSymlink` mechanism with a `.worktree-symlinks` file at the main worktree root (one repo-root-relative path per line)
- Support blank lines, `#` comments, and surrounding-whitespace/CRLF trimming in the config file
- Reject absolute paths and paths containing `..` segments with a warning, since the config file can now be committed and shared
- Rewrite tests to set up config via the file and add coverage for: missing config file (silent), comments/blank lines, and unsafe path rejection

## Test plan

- [x] `bash programs/git/hooks/post-checkout.test.sh` — 22 passed, 0 failed
