### PR TITLE
feat(claude): forbid gh api contents fetch in pre-bash hook

### DIFF
--- a/programs/claude/nownabe-claude-hooks.json
+++ b/programs/claude/nownabe-claude-hooks.json
@@ -52,6 +52,11 @@
         "type": "regex",
         "reason": "`sed` is forbidden.",
         "suggestion": "Use the Edit or Read tool instead of `sed`."
+      },
+      "^gh\\s+api\\b.*\\brepos/\\S+/contents\\b": {
+        "type": "regex",
+        "reason": "Fetching file content via `gh api repos/.../contents/...` is forbidden.",
+        "suggestion": "Clone the repository into `.local/src/github.com/<owner>/<repo>` and read the files locally with the Read tool instead."
       }
     }
   }


### PR DESCRIPTION
## Summary

- Add a forbidden pattern `^gh\s+api\b.*\brepos/\S+/contents\b` to `programs/claude/nownabe-claude-hooks.json`
- Commands like `gh api repos/<owner>/<repo>/contents/<path>` are now denied, with a suggestion to clone the repository into `.local/src/github.com/<owner>/<repo>` and read files locally with the Read tool

## Test plan

- [x] `jq empty` validates the JSON
- [x] `gh api repos/zizmorcore/zizmor-action/contents/action.yml --jq .content` → denied with clone suggestion
- [x] `gh api repos/zizmorcore/zizmor-action/pulls` → not matched (other `gh api` calls unaffected)
- [x] `git commit -m "docs: mention gh api repos/foo/bar/contents usage"` → not matched (quoted argument does not trip the rule)