### PR TITLE
fix(nix): strip alsa-lib LD_LIBRARY_PATH from claude-code wrapper

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,7 @@
       overlay = final: prev: {
         aqua = final.callPackage ./packages/aqua.nix { };
         chikuwa = final.callPackage ./packages/chikuwa.nix { };
+        claude-code = final.callPackage ./packages/claude-code.nix { inherit (prev) claude-code; };
         mo = final.callPackage ./packages/mo.nix { };
       };
       pkgs = import nixpkgs {

--- a/packages/claude-code.nix
+++ b/packages/claude-code.nix
@@ -1,0 +1,22 @@
+# nixpkgs' claude-code wraps the binary with LD_LIBRARY_PATH pointing at Nix's
+# alsa-lib (for sound notifications). The variable leaks into every subprocess
+# Claude Code spawns, so non-Nix binaries — e.g. the system Chrome launched by
+# the playwright / chrome-devtools MCP servers — load Nix libraries built
+# against a newer glibc and crash with GLIBC_ABI_* version errors.
+# Strip the LD_LIBRARY_PATH prefix from the wrapper.
+{
+  lib,
+  alsa-lib,
+  claude-code,
+}:
+
+claude-code.overrideAttrs (old: {
+  installPhase =
+    let
+      alsaPrefix = "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ alsa-lib ]} \\\n";
+      stripped = lib.replaceStrings [ alsaPrefix ] [ "" ] old.installPhase;
+    in
+    assert lib.assertMsg (stripped != old.installPhase)
+      "claude-code: LD_LIBRARY_PATH prefix not found in installPhase; update packages/claude-code.nix";
+    stripped;
+})


### PR DESCRIPTION
## Summary

- Playwright MCP and chrome-devtools MCP could not launch a browser on this machine. The MCP servers connected fine, but Chrome crashed at launch with:
  ```
  /opt/google/chrome/chrome: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_ABI_GNU2_TLS' not found (required by /nix/store/...-alsa-lib-1.2.16.1/lib/libasound.so.2)
  ```
- Root cause: nixpkgs' `claude-code` package wraps the binary with `--prefix LD_LIBRARY_PATH : ${alsa-lib}/lib` on Linux. This variable leaks into every subprocess Claude Code spawns (MCP servers → Chrome), so the FHS system Chrome loads Nix's alsa-lib built against glibc 2.42 while linking the host's older glibc, and crashes.
- Fix: add `packages/claude-code.nix` overlay that strips the `LD_LIBRARY_PATH` prefix from the wrapper's `installPhase`. An assertion fails the build if upstream changes the wrapper so the override silently stops matching.
- Trade-off: Claude Code's built-in ALSA sound notification (the reason upstream adds alsa-lib) is disabled; notification sounds are handled by `@nownabe/claude-hooks` instead.

## Test plan

- [x] `nix build` of the overridden `claude-code` succeeds (includes upstream `--version` install check)
- [x] `strings bin/claude` on the new wrapper shows only the `PATH` prefix — no `LD_LIBRARY_PATH`
- [x] `statix` / `deadnix` / `nix flake check --no-build` pass
- [ ] `hms`, restart Claude Code, and confirm playwright / chrome-devtools MCP can launch Chrome
