### PR TITLE
chore(claude): set default model to fable 5 with 1m context

### DIFF
--- a/programs/claude/settings.json
+++ b/programs/claude/settings.json
@@ -66,6 +66,7 @@
     ],
     "ask": ["Bash(gh api:*)", "Bash(gh issue close:*)"]
   },
+  "model": "claude-fable-5[1m]",
   "hooks": {
     "SessionStart": [
       {


### PR DESCRIPTION
## Summary

- Persist the Claude Code default model as `claude-fable-5[1m]` in `programs/claude/settings.json`

This was already set in the live `~/.claude/settings.json` (written by `/model`), which is a symlink into this repo. Committing it makes the setting reproducible from dotfiles alone. The reformatting of the `permissions.ask` array that `/model` also introduced was reverted to keep the diff to a single line.

## Test plan

- [x] `git diff` shows only the added `"model"` line
- [x] `jq . programs/claude/settings.json` parses cleanly
- [ ] Start a new Claude Code session and confirm `/model` reports Fable 5 (1M context) as the default
