### PR TITLE
feat(claude): make grilling ask via AskUserQuestion

### DIFF
--- a/programs/claude/README.md
+++ b/programs/claude/README.md
@@ -6,16 +6,18 @@ Global skills, symlinked to `~/.claude/skills` by Home Manager.
 
 ### Vendored skills
 
-The following skills are copied from [mattpocock/skills](https://github.com/mattpocock/skills) (MIT, Copyright (c) 2026 Matt Pocock) at commit `84fdeffd12f2ee307994d1eb6feb48173b6e0502`. Only the `SKILL.md` (and its reference docs) are vendored; the upstream `agents/openai.yaml` files are Codex-specific and omitted. Content is unchanged apart from `oxfmt` reformatting (emphasis markers, table padding).
+The following skills are copied from [mattpocock/skills](https://github.com/mattpocock/skills) (MIT, Copyright (c) 2026 Matt Pocock) at commit `84fdeffd12f2ee307994d1eb6feb48173b6e0502`. Only the `SKILL.md` (and its reference docs) are vendored; the upstream `agents/openai.yaml` files are Codex-specific and omitted. Apart from the local changes noted below, content differs from upstream only by `oxfmt` reformatting (emphasis markers, table padding).
 
-| Skill             | Invocation    | Upstream path                        |
-| ----------------- | ------------- | ------------------------------------ |
-| `grilling`        | Model or user | `skills/productivity/grilling`       |
-| `grill-me`        | User only     | `skills/productivity/grill-me`       |
-| `grill-with-docs` | User only     | `skills/engineering/grill-with-docs` |
-| `domain-modeling` | Model or user | `skills/engineering/domain-modeling` |
+| Skill             | Invocation    | Upstream path                        | Local changes              |
+| ----------------- | ------------- | ------------------------------------ | -------------------------- |
+| `grilling`        | Model or user | `skills/productivity/grilling`       | Asks via `AskUserQuestion` |
+| `grill-me`        | User only     | `skills/productivity/grill-me`       | —                          |
+| `grill-with-docs` | User only     | `skills/engineering/grill-with-docs` | —                          |
+| `domain-modeling` | Model or user | `skills/engineering/domain-modeling` | —                          |
 
-`grill-me` and `grill-with-docs` are thin entrypoints that delegate to `grilling`; `grill-with-docs` additionally uses `domain-modeling`. To refresh, re-copy from upstream and update the commit above.
+`grill-me` and `grill-with-docs` are thin entrypoints that delegate to `grilling`; `grill-with-docs` additionally uses `domain-modeling`.
+
+`grilling` is locally modified: upstream asks the whole frontier as numbered prose, this copy drives the same rounds through the `AskUserQuestion` tool with pre-computed options and a marked recommendation, keeping prose only for questions that genuinely have no enumerable answers. Re-copying it from upstream would drop that — diff before overwriting. The other three can be refreshed by straight re-copy; update the commit above when you do.
 
 ## pre-bash.json
 

--- a/programs/claude/skills/grilling/SKILL.md
+++ b/programs/claude/skills/grilling/SKILL.md
@@ -5,18 +5,42 @@ description: Grill the user relentlessly about a plan, decision, or idea. Use wh
 
 Interview the user relentlessly until you reach a shared understanding. Map this as a **design tree**: every decision branches into the decisions that hang off it.
 
-Work the tree in **rounds**. The **frontier** is every decision whose prerequisites are already settled — the questions you can ask _now_ without guessing at answers you haven't heard yet. Ask the whole frontier in one round: number each question and give your recommended answer. Then wait for the user's answers before the next round.
-
-Each question should be formatted like so:
-
-```
-❓ **Q1** - **<question title>**: <question body, might be multiple paragraphs, including multiple choices>
-
-➡️ <your recommended answer>
-```
+Work the tree in **rounds**. The **frontier** is every decision whose prerequisites are already settled — the questions you can ask _now_ without guessing at answers you haven't heard yet. Ask the whole frontier in one round, then wait for the user's answers before the next round.
 
 Each round the user answers reshapes the tree — settled decisions push the frontier outward and unblock questions that depended on them. Recompute the frontier and ask the next round. A question whose answer depends on another question still open in this round belongs to a _later_ round, not this one.
 
 Finding _facts_ is your job, never the user's. When a frontier question needs a fact from the environment (filesystem, tools, etc.), dispatch a sub-agent to find it — don't ask the user for anything you could look up yourself. Don't block on it: a running exploration is an unsettled prerequisite, so only the questions downstream of it wait for the sub-agent to report — ask the rest of the frontier now. The _decisions_ are the user's — put each to them and wait.
+
+## Ask with the AskUserQuestion tool
+
+Use `AskUserQuestion` for every frontier question you can. Picking costs the user far less than composing prose, and a question you were able to write options for is a question you were forced to think through first.
+
+Earn the options before you offer them. For each question:
+
+1. **Find the real candidates.** Read the code, check the constraints, look at what the surrounding system already does. Options invented at the keyboard are filler and the user will feel it.
+2. **Cut to the live ones.** Keep only answers that are genuinely on the table, mutually exclusive, and lead to materially different work. Two sharp options beat four padded ones. Never add a straw option to make your favourite look good — the user's real answer may well be the one you rank last.
+3. **Commit to a recommendation.** Decide what you would actually ship and why. Put it first and end its label with `(Recommended)`.
+4. **Spend the `description` on the trade-off.** What the option buys and what it costs — never a restatement of the label.
+
+Tool mechanics worth using well:
+
+- Up to 4 questions per call, 2–4 options each, `header` at most 12 characters.
+- "Other" is always offered automatically. Never write your own escape-hatch option.
+- `multiSelect: true` when the choices are not mutually exclusive.
+- `preview` when the options are concrete artifacts worth comparing side by side — a layout, a schema, a snippet, a directory shape. Single-select only.
+
+If the frontier is wider than four questions, ask it in back-to-back calls within the same round. Don't act between the calls, and don't quietly drop the remainder.
+
+## Falling back to prose
+
+A question earns prose only when you genuinely cannot name two real options — the answer is a number, a name, or a piece of context that lives only in the user's head. Don't reach for it just because enumerating is hard work; that is the work. Then ask like so:
+
+```
+❓ **Q1** - **<question title>**: <question body, might be multiple paragraphs>
+
+➡️ <your recommended answer>
+```
+
+## Finishing
 
 The session is done when the frontier is empty: every branch of the design tree visited, nothing left silently assumed. Do not act on it until the user confirms you have reached a shared understanding.


### PR DESCRIPTION
## Summary

- Rework the vendored `grilling` skill to drive each round through the `AskUserQuestion` tool instead of numbered prose
- Require the options to be earned before they are offered: find the real candidates from the code and constraints, cut to the ones that are genuinely live and mutually exclusive, commit to a recommendation (first option, labelled `(Recommended)`), and spend each option's `description` on the trade-off rather than restating the label
- Explicitly forbid straw options that exist to flatter the recommendation
- Document the tool mechanics the skill should exploit — the 4-question / 4-option caps, the 12-char `header`, the automatic "Other" (so no hand-written escape hatch), `multiSelect` for non-exclusive choices, `preview` for comparing concrete artifacts
- Keep prose as a narrow fallback for questions with no enumerable answers (a number, a name, context that only lives in the user's head), retaining the original `❓`/`➡️` format
- Handle a frontier wider than four questions with back-to-back calls in the same round, with no acting in between and no silent truncation
- Note the local divergence in `programs/claude/README.md` so a future upstream re-copy doesn't silently revert it

The design-tree / rounds / frontier model and the "facts are your job, decisions are the user's" rule are unchanged.

## Test plan

- [x] `oxfmt --check programs/claude/` passes
- [x] `grilling` still loads as a model-invocable skill from `~/.claude/skills`
- [ ] Run `/grill-me` on a real design question and confirm the first round arrives as an `AskUserQuestion` call with recommendations marked, not as numbered prose
- [ ] Confirm a frontier wider than 4 questions comes through as consecutive calls within one round
- [ ] Confirm a genuinely open-ended question (e.g. "what should this be named?") still falls back to the `❓`/`➡️` prose format
