### PR TITLE
feat(nix): add podman with rootless containers config

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -9,6 +9,7 @@
     ./programs/wezterm
     ./programs/tmux
     ./programs/gnome-terminal
+    ./programs/podman
   ];
 
   home = {

--- a/programs/podman/default.nix
+++ b/programs/podman/default.nix
@@ -8,13 +8,9 @@
   home.packages = [ pkgs.podman ];
 
   # Non-NixOS has no /etc/containers, so provide user-level config.
-  xdg.configFile = {
-    "containers/policy.json".text = builtins.toJSON {
-      default = [ { type = "insecureAcceptAnything"; } ];
-    };
-
-    "containers/registries.conf".text = ''
-      unqualified-search-registries = ["docker.io"]
-    '';
+  # No registries.conf: always use fully qualified image names
+  # (e.g. docker.io/library/ubuntu).
+  xdg.configFile."containers/policy.json".text = builtins.toJSON {
+    default = [ { type = "insecureAcceptAnything"; } ];
   };
 }

--- a/programs/podman/default.nix
+++ b/programs/podman/default.nix
@@ -1,0 +1,20 @@
+{ pkgs, ... }:
+
+{
+  # Rootless Podman on non-NixOS.
+  # Host prerequisites (provided by Ubuntu, not Nix):
+  #   - setuid /usr/bin/newuidmap & newgidmap (uidmap package)
+  #   - subuid/subgid entries for the user in /etc/subuid & /etc/subgid
+  home.packages = [ pkgs.podman ];
+
+  # Non-NixOS has no /etc/containers, so provide user-level config.
+  xdg.configFile = {
+    "containers/policy.json".text = builtins.toJSON {
+      default = [ { type = "insecureAcceptAnything"; } ];
+    };
+
+    "containers/registries.conf".text = ''
+      unqualified-search-registries = ["docker.io"]
+    '';
+  };
+}


### PR DESCRIPTION
## Summary

- Add Podman (5.8.4) as a Home Manager module at `programs/podman/`
- Install `pkgs.podman` (wrapped package bundling crun, conmon, netavark, aardvark-dns, etc.)
- Provide user-level `~/.config/containers/policy.json` via `xdg.configFile` (non-NixOS has no `/etc/containers`), with the standard `insecureAcceptAnything` default policy — the same posture as Docker and distro-shipped defaults
- No `registries.conf`: short names are intentionally unsupported; always use fully qualified image names (e.g. `docker.io/library/ubuntu`)
- Rootless prerequisites (setuid `newuidmap`/`newgidmap`, subuid/subgid entries) are provided by Ubuntu and documented in the module comment

## Test plan

- [x] `home-manager build --flake .#wsl` succeeds
- [x] `home-manager switch --flake .#wsl` applied
- [x] `podman info` reports rootless mode with `overlay` storage driver and `crun` runtime
- [x] `podman run --rm docker.io/library/hello-world` runs successfully (pull + run end-to-end)
- [x] `podman pull ubuntu` (short name) fails as intended
