### PR TITLE
feat(claude): set default permission mode to auto

### DIFF
--- a/programs/claude/settings.json
+++ b/programs/claude/settings.json
@@ -65,10 +65,7 @@
       "Read(~/.aws/**)",
       "Read(~/.gcloud/**)"
     ],
-    "ask": [
-      "Bash(gh api:*)",
-      "Bash(gh issue close:*)"
-    ]
+    "ask": ["Bash(gh api:*)", "Bash(gh issue close:*)"]
   },
   "hooks": {
     "SessionStart": [

--- a/programs/claude/settings.json
+++ b/programs/claude/settings.json
@@ -8,6 +8,7 @@
     "pr": ""
   },
   "permissions": {
+    "defaultMode": "auto",
     "allow": [
       "Bash(bun test:*)",
       "Bash(bunx @nownabe/claude-tools:*)",
@@ -64,7 +65,10 @@
       "Read(~/.aws/**)",
       "Read(~/.gcloud/**)"
     ],
-    "ask": ["Bash(gh api:*)", "Bash(gh issue close:*)"]
+    "ask": [
+      "Bash(gh api:*)",
+      "Bash(gh issue close:*)"
+    ]
   },
   "hooks": {
     "SessionStart": [
@@ -269,5 +273,6 @@
       }
     }
   },
-  "tui": "fullscreen"
+  "tui": "fullscreen",
+  "model": "claude-fable-5[1m]"
 }


### PR DESCRIPTION
## Summary

- Set `permissions.defaultMode` to `auto` in the global Claude Code settings (`programs/claude/settings.json`), making auto mode the default permission mode for all sessions
- Includes two pre-existing uncommitted changes in the same file: the `model: claude-fable-5[1m]` setting and reformatting of the `ask` array

## Test plan

- [x] `jq -e '.permissions.defaultMode' programs/claude/settings.json` returns `"auto"`
- [x] Applied with `hms` successfully
- [x] Verified `~/.claude/settings.json` (Home Manager symlink) resolves `defaultMode` to `auto`