### PR TITLE
feat(nix): add forgejo-cli package

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -21,6 +21,7 @@
       # Version control
       gh
       ghq
+      forgejo-cli
 
       # Languages & runtimes
       go


### PR DESCRIPTION
## Summary

- Add `forgejo-cli` (v0.6.0, provides the `fj` command) to home packages for interacting with Forgejo instances

## Test plan

- [x] `nix build .#homeConfigurations.wsl.activationPackage` succeeds
- [ ] Apply with `hms` and verify `fj --version` works