### PR TITLE
feat(claude): set dotfiles project permission mode to auto

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,9 +1,13 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "permissions": {
-    "defaultMode": "acceptEdits",
-    "additionalDirectories": ["~/src/github.com/nownabe/claude"],
-    "deny": ["Edit(~/src/github.com/nownabe/claude/**)"],
+    "defaultMode": "auto",
+    "additionalDirectories": [
+      "~/src/github.com/nownabe/claude"
+    ],
+    "deny": [
+      "Edit(~/src/github.com/nownabe/claude/**)"
+    ],
     "allow": [
       "Bash(gh api repos/nownabe/claude/contents*)",
       "Bash(gh issue view:*)",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,12 +2,8 @@
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "permissions": {
     "defaultMode": "auto",
-    "additionalDirectories": [
-      "~/src/github.com/nownabe/claude"
-    ],
-    "deny": [
-      "Edit(~/src/github.com/nownabe/claude/**)"
-    ],
+    "additionalDirectories": ["~/src/github.com/nownabe/claude"],
+    "deny": ["Edit(~/src/github.com/nownabe/claude/**)"],
     "allow": [
       "Bash(gh api repos/nownabe/claude/contents*)",
       "Bash(gh issue view:*)",

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dot_git/
 result
 node_modules/
+.playwright-mcp/


### PR DESCRIPTION
## Summary

- Change `permissions.defaultMode` from `acceptEdits` to `auto` in the dotfiles project-level `.claude/settings.json`, following the global default change in #353
- Add `.playwright-mcp/` to `.gitignore`

## Test plan

- [x] CI checks pass (including oxfmt)
- [ ] Start a Claude Code session in the dotfiles repo and confirm the permission mode is `auto`