### PR TITLE
feat(zsh): load machine-local config from ~/.config/zsh/local.d

### DIFF
--- a/programs/zsh/default.nix
+++ b/programs/zsh/default.nix
@@ -93,6 +93,14 @@ in
       for file in "''${XDG_CONFIG_HOME:-$HOME/.config}/zsh"/*.zsh; do
         [[ -f "$file" ]] && source "$file"
       done
+
+      # Load machine-local config files from ~/.config/zsh/local.d/
+      # Not managed by Nix and never committed: put host-specific values
+      # (private hostnames, IPs, ports, tokens) here. Loaded last so they
+      # can override anything above.
+      for file in "''${XDG_CONFIG_HOME:-$HOME/.config}/zsh/local.d"/*.zsh; do
+        [[ -f "$file" ]] && source "$file"
+      done
     '';
   };
 }


### PR DESCRIPTION
## Summary

- Load `~/.config/zsh/local.d/*.zsh` at the end of zsh startup, after the Nix-managed `~/.config/zsh/*.zsh` files
- The directory is not managed by Nix and never committed, so host-specific values (private hostnames, IPs, ports, tokens) stay out of this public repository
- Loaded last, so local files can override anything defined above

Motivation: enabling Claude Code OpenTelemetry export requires `OTEL_EXPORTER_OTLP_ENDPOINT` pointing at a private tailnet host, plus a per-machine `host.name` resource attribute. Neither belongs in a public repo, and static `settings.json` cannot resolve the hostname per machine.

## Test plan

- [x] `nix-instantiate --parse programs/zsh/default.nix` succeeds
- [x] `nix flake check --no-build` evaluates `homeConfigurations` without error
- [x] The loop sources a file placed in `~/.config/zsh/local.d/` and exports its variables
- [x] The loop is a no-op when `local.d/` is absent or empty (guarded by `[[ -f ]]`)
- [ ] `hms` applies cleanly and a new shell has the expected variables
