### PR TITLE
refactor(claude): symlink skill files individually

### DIFF
--- a/programs/claude/default.nix
+++ b/programs/claude/default.nix
@@ -1,7 +1,24 @@
-{ config, dotfilesDir, ... }:
+{ config, lib, dotfilesDir, ... }:
 
+let
+  # Symlink each skill file individually (not the skills directory itself)
+  # so ~/.claude/skills stays a real directory where unmanaged local skills
+  # can coexist. New files in skills/ require re-running `hms` to be linked.
+  skillLinks = lib.listToAttrs (
+    map (
+      file:
+      let
+        rel = lib.removePrefix "${toString ./skills}/" (toString file);
+      in
+      {
+        name = ".claude/skills/${rel}";
+        value.source = config.lib.file.mkOutOfStoreSymlink "${dotfilesDir}/programs/claude/skills/${rel}";
+      }
+    ) (lib.filesystem.listFilesRecursive ./skills)
+  );
+in
 {
-  home.file = {
+  home.file = skillLinks // {
     ".claude/CLAUDE.md".source =
       config.lib.file.mkOutOfStoreSymlink "${dotfilesDir}/programs/claude/CLAUDE.md";
 
@@ -13,8 +30,5 @@
 
     ".claude/scripts/statusline-command.sh".source =
       config.lib.file.mkOutOfStoreSymlink "${dotfilesDir}/programs/claude/scripts/statusline-command.sh";
-
-    ".claude/skills".source =
-      config.lib.file.mkOutOfStoreSymlink "${dotfilesDir}/programs/claude/skills";
   };
 }


### PR DESCRIPTION
## Summary

- Replace the single directory symlink for `~/.claude/skills` with per-file symlinks
- Enumerate `programs/claude/skills/` with `lib.filesystem.listFilesRecursive` and create one `mkOutOfStoreSymlink` entry per file
- `~/.claude/skills` is now a real directory, so unmanaged local skills can coexist with repo-managed ones

## Test plan

- [x] `home-manager switch --flake ~/.dotfiles#wsl` succeeds
- [x] `~/.claude/skills` is a real directory (not a symlink)
- [x] All 7 skill files are symlinks resolving to `programs/claude/skills/` in the repo

Note: the stale directory symlink from the previous generation must be removed manually once (`rm ~/.claude/skills`) before switching, otherwise Home Manager skips creating the per-file links because the same content already "exists" through the old symlink.
