### PR TITLE
fix(zsh): use nullglob qualifier when loading config files

### DIFF
--- a/programs/zsh/default.nix
+++ b/programs/zsh/default.nix
@@ -90,7 +90,7 @@ in
 
     initContent = ''
       # Load config files from ~/.config/zsh/
-      for file in "''${XDG_CONFIG_HOME:-$HOME/.config}/zsh"/*.zsh; do
+      for file in "''${XDG_CONFIG_HOME:-$HOME/.config}/zsh"/*.zsh(N); do
         [[ -f "$file" ]] && source "$file"
       done
 
@@ -98,7 +98,7 @@ in
       # Not managed by Nix and never committed: put host-specific values
       # (private hostnames, IPs, ports, tokens) here. Loaded last so they
       # can override anything above.
-      for file in "''${XDG_CONFIG_HOME:-$HOME/.config}/zsh/local.d"/*.zsh; do
+      for file in "''${XDG_CONFIG_HOME:-$HOME/.config}/zsh/local.d"/*.zsh(N); do
         [[ -f "$file" ]] && source "$file"
       done
     '';


### PR DESCRIPTION
## Summary

- Fix `.zshrc` aborting with `no matches found: ~/.config/zsh/local.d/*.zsh` when `local.d/` has no `.zsh` files (introduced in #358)
- The abort stopped `.zshrc` mid-load, so all shell aliases defined after the loop (`g`, `k`, `hms`, ...) were never set
- Add the `(N)` nullglob qualifier to both config-loading globs so an empty match expands to nothing

## Test plan

- [x] `home-manager switch --flake ~/.dotfiles#wsl` succeeds
- [x] `zsh -ic 'alias g'` prints `g=git` with no glob error
